### PR TITLE
Setup heroku build for server

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+build

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ scripts
 .DS_Store
 
 server/.env
+
+# build
+build/

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node server/build/app.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,6 +234,11 @@
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
             "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
         },
+        "@types/uuid": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.3.tgz",
+            "integrity": "sha512-PUdqTZVrNYTNcIhLHkiaYzoOIaUi5LFg/XLerAdgvwQrUCx+oSbtoBze1AMyvYbcwzUSNC+Isl58SM4Sm/6COw=="
+        },
         "@typescript-eslint/eslint-plugin": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dependencies": {
         "@types/express": "^4.17.6",
         "@types/jquery": "^3.3.33",
+        "@types/uuid": "^7.0.3",
         "aws-sdk": "^2.656.0",
         "babel-eslint": "^10.1.0",
         "eslint": "^6.8.0",
@@ -27,6 +28,7 @@
         "eslint-plugin-react-hooks": "^1.7.0"
     },
     "scripts": {
+        "heroku-postbuild": "cd server && npm run tsc",
         "install:frontend": "cd frontend && npm install && cd ..",
         "install:server": "cd server && npm install && cd ..",
         "postinstall": "npm run install:frontend && npm run install:server",

--- a/server/app.ts
+++ b/server/app.ts
@@ -12,7 +12,7 @@ import vehicle from './router/vehicle';
 import location from './router/location';
 import auth from './router/auth';
 
-const port = 3001;
+const port = process.env.PORT || 3001;
 
 dynamoose.aws.sdk.config.update(config);
 
@@ -28,5 +28,6 @@ app.use('/past-rides', pastride);
 app.use('/vehicles', vehicle);
 app.use('/locations', location);
 app.use('/auth', auth);
+app.get('/health-check', (_, response) => response.status(200).send('OK'));
 
 app.listen(port, () => console.log('Listening at port', port));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,86 +19,16 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
-        "@types/body-parser": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-            "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-            "dev": true,
-            "requires": {
-                "@types/connect": "*",
-                "@types/node": "*"
-            }
-        },
         "@types/color-name": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
-        "@types/connect": {
-            "version": "3.4.33",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-            "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/express": {
-            "version": "4.17.6",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-            "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
-            "dev": true,
-            "requires": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "*",
-                "@types/qs": "*",
-                "@types/serve-static": "*"
-            }
-        },
-        "@types/express-serve-static-core": {
-            "version": "4.17.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.6.tgz",
-            "integrity": "sha512-U2oynuRIB17GIbEdvjFrrEACOy7GQkzsX7bPEBz1H41vZYEU4j0fLL97sawmHDwHUXpUQDBMHIyM9vejqP9o1A==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*"
-            }
-        },
-        "@types/mime": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-            "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
-            "dev": true
-        },
         "@types/node": {
             "version": "13.13.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
             "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
-        },
-        "@types/qs": {
-            "version": "6.9.2",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.2.tgz",
-            "integrity": "sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A==",
-            "dev": true
-        },
-        "@types/range-parser": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-            "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
-            "dev": true
-        },
-        "@types/serve-static": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-            "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-            "dev": true,
-            "requires": {
-                "@types/express-serve-static-core": "*",
-                "@types/mime": "*"
-            }
         },
         "@types/source-map-support": {
             "version": "0.5.1",
@@ -107,12 +37,6 @@
             "requires": {
                 "@types/node": "*"
             }
-        },
-        "@types/uuid": {
-            "version": "3.4.9",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-            "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==",
-            "dev": true
         },
         "abbrev": {
             "version": "1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -15,14 +15,13 @@
         "uuid": "^3.4.0"
     },
     "devDependencies": {
-        "@types/express": "^4.17.6",
-        "@types/uuid": "^3.4.9",
         "nodemon": "^2.0.3",
         "ts-node": "^8.10.1",
         "typescript": "^3.8.3"
     },
     "scripts": {
         "start": "nodemon --exec \"ts-node\" --watch router app.ts",
+        "tsc": "tsc --noEmit false",
         "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "esnext"
         ],
+        "outDir": "build",
         "allowJs": true,
         "skipLibCheck": true,
         "esModuleInterop": true,


### PR DESCRIPTION
### Summary <!-- Required -->

This PR makes the repo buildable on heroku. The diff focuses on backend only, since it's a more urgent need for mobile developers.

Heroku will purge devDependencies once everything is built. Therefore, we cannot rely on the current setup that requires ts-node and typescript. We must compile the server side TS code to JS. To achieve that, I added the `heroku-postbuild` hook that calls `tsc` to emit JS code. We also need to add a Procfile to tell heroku what to run.

### Test Plan <!-- Required -->

Find the deployment card, visit the deployment with the `/health-check` endpoint. You should see plain text `OK`.