### PR TITLE
Update ride schema, add populate functionality to rides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2391,9 +2391,9 @@
             }
         },
         "typescript": {
-            "version": "3.7.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-            "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+            "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
         },
         "unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "express": "^4.17.1",
         "google-auth-library": "^6.0.0",
         "react-google-login": "^5.1.3",
-        "typescript": "^3.7.5"
+        "typescript": "^4.0.3"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^2.18.0",

--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -1,4 +1,7 @@
 import dynamoose from 'dynamoose';
+import { Location, LocationType } from './location';
+import { Rider, RiderType } from './rider';
+import { Driver, DriverType } from './driver';
 
 export enum Type {
   ACTIVE = 'active',
@@ -7,32 +10,31 @@ export enum Type {
 }
 
 export type RideType = {
-  type: Type,
   id: string,
-  startLocation: string,
-  endLocation: string,
+  type: Type,
+  startLocation: LocationType,
+  endLocation: LocationType,
   startTime: string,
   endTime: string,
-  riderId: string,
-  driverId?: string,
+  rider: RiderType,
+  driver?: DriverType,
 };
 
 const schema = new dynamoose.Schema({
-  type: {
+  id: {
     hashKey: true,
+    type: String,
+  },
+  type: {
     type: String,
     enum: Object.values(Type),
   },
-  id: {
-    rangeKey: true,
-    type: String,
-  },
-  startLocation: String,
-  endLocation: String,
+  startLocation: Location as any,
+  endLocation: Location as any,
   startTime: String,
   endTime: String,
-  riderId: String,
-  driverId: String,
+  rider: Rider as any,
+  driver: Driver as any,
 });
 
 export const Ride = dynamoose.model('Rides', schema, { create: false });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -587,9 +587,9 @@
             "dev": true
         },
         "dynamoose": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-2.2.1.tgz",
-            "integrity": "sha512-VICnSuDnHNYEbrol0H+Lbg5/FlhImowrvOh6Rf8GmCmW894rzeqlUnlN0G/trY06s4vD93VsIuxjk8xrG665KA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-2.3.0.tgz",
+            "integrity": "sha512-XfaPu3eXctD1NiRNzSvjoJvPAuAAHW8jY5wwYXnkVuizTolS4D8R9mAwuKYenK6+eZwHCAgoJEPYE2caFlJWhA==",
             "requires": {
                 "@types/node": "^13.13.4",
                 "@types/source-map-support": "^0.5.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7,14 +7,12 @@
         "@sindresorhus/is": {
             "version": "0.14.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-            "dev": true
+            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
         },
         "@szmarczak/http-timer": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
             "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-            "dev": true,
             "requires": {
                 "defer-to-connect": "^1.0.1"
             }
@@ -31,8 +29,7 @@
         "@types/color-name": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-            "dev": true
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "@types/connect": {
             "version": "3.4.33",
@@ -108,8 +105,7 @@
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "dev": true
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "abort-controller": {
             "version": "3.0.0",
@@ -150,7 +146,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
             "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-            "dev": true,
             "requires": {
                 "string-width": "^3.0.0"
             },
@@ -159,7 +154,6 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
                     "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
                     "requires": {
                         "emoji-regex": "^7.0.1",
                         "is-fullwidth-code-point": "^2.0.0",
@@ -171,14 +165,12 @@
         "ansi-regex": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-            "dev": true
+            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "ansi-styles": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
             "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-            "dev": true,
             "requires": {
                 "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
@@ -188,7 +180,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
             "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-            "dev": true,
             "requires": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -197,8 +188,7 @@
         "arg": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
         },
         "array-flatten": {
             "version": "1.1.1",
@@ -236,8 +226,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base64-js": {
             "version": "1.3.1",
@@ -252,8 +241,7 @@
         "binary-extensions": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-            "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-            "dev": true
+            "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
         },
         "body-parser": {
             "version": "1.19.0",
@@ -291,7 +279,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
             "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
-            "dev": true,
             "requires": {
                 "ansi-align": "^3.0.0",
                 "camelcase": "^5.3.1",
@@ -307,7 +294,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -317,7 +303,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -351,7 +336,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
             "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-            "dev": true,
             "requires": {
                 "clone-response": "^1.0.2",
                 "get-stream": "^5.1.0",
@@ -366,7 +350,6 @@
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
                     "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-                    "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
                     }
@@ -374,22 +357,19 @@
                 "lowercase-keys": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-                    "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-                    "dev": true
+                    "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
                 }
             }
         },
         "camelcase": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-            "dev": true
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "chalk": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
             "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -398,14 +378,12 @@
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
                 "supports-color": {
                     "version": "7.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -416,7 +394,6 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
             "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
-            "dev": true,
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -431,20 +408,17 @@
         "ci-info": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-            "dev": true
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
         },
         "cli-boxes": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-            "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
-            "dev": true
+            "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
         },
         "clone-response": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
             "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-            "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
             }
@@ -453,7 +427,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
@@ -461,20 +434,17 @@
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "configstore": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
             "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-            "dev": true,
             "requires": {
                 "dot-prop": "^5.2.0",
                 "graceful-fs": "^4.1.2",
@@ -517,14 +487,12 @@
         "crypto-random-string": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-            "dev": true
+            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
         },
         "debug": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
             "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -533,7 +501,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-            "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
             }
@@ -541,14 +508,12 @@
         "deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "defer-to-connect": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-            "dev": true
+            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
         },
         "depd": {
             "version": "1.1.2",
@@ -563,14 +528,12 @@
         "diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         },
         "dot-prop": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
             "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
-            "dev": true,
             "requires": {
                 "is-obj": "^2.0.0"
             }
@@ -583,8 +546,7 @@
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-            "dev": true
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "dynamoose": {
             "version": "2.3.0",
@@ -621,8 +583,7 @@
         "emoji-regex": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-            "dev": true
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -633,7 +594,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -641,8 +601,7 @@
         "escape-goat": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
-            "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
-            "dev": true
+            "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q=="
         },
         "escape-html": {
             "version": "1.0.3",
@@ -735,7 +694,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -783,7 +741,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
             "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-            "dev": true,
             "optional": true
         },
         "gaxios": {
@@ -811,7 +768,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
             "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "dev": true,
             "requires": {
                 "pump": "^3.0.0"
             }
@@ -820,7 +776,6 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
             "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-            "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
             }
@@ -829,7 +784,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
             "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
-            "dev": true,
             "requires": {
                 "ini": "^1.3.5"
             }
@@ -862,7 +816,6 @@
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
             "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-            "dev": true,
             "requires": {
                 "@sindresorhus/is": "^0.14.0",
                 "@szmarczak/http-timer": "^1.1.2",
@@ -880,8 +833,7 @@
         "graceful-fs": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-            "dev": true
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "gtoken": {
             "version": "4.1.4",
@@ -897,20 +849,17 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-yarn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-            "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
-            "dev": true
+            "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
         },
         "http-cache-semantics": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-            "dev": true
+            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
         },
         "http-errors": {
             "version": "1.7.2",
@@ -966,26 +915,22 @@
         "ignore-by-default": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-            "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-            "dev": true
+            "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
         },
         "import-lazy": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-            "dev": true
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
         },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "dev": true
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "ipaddr.js": {
             "version": "1.9.0",
@@ -996,7 +941,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
@@ -1005,7 +949,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-            "dev": true,
             "requires": {
                 "ci-info": "^2.0.0"
             }
@@ -1013,20 +956,17 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-glob": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -1035,7 +975,6 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
             "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
-            "dev": true,
             "requires": {
                 "global-dirs": "^2.0.1",
                 "is-path-inside": "^3.0.1"
@@ -1044,26 +983,22 @@
         "is-npm": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-            "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
-            "dev": true
+            "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig=="
         },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "is-obj": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-            "dev": true
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "is-path-inside": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-            "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
-            "dev": true
+            "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
         },
         "is-stream": {
             "version": "2.0.0",
@@ -1073,14 +1008,12 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "is-yarn-global": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-            "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
-            "dev": true
+            "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
         },
         "isarray": {
             "version": "1.0.0",
@@ -1103,8 +1036,7 @@
         "json-buffer": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-            "dev": true
+            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
         },
         "jwa": {
             "version": "2.0.0",
@@ -1129,7 +1061,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
             "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-            "dev": true,
             "requires": {
                 "json-buffer": "3.0.0"
             }
@@ -1138,7 +1069,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
             "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-            "dev": true,
             "requires": {
                 "package-json": "^6.3.0"
             }
@@ -1146,8 +1076,7 @@
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-            "dev": true
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lru-cache": {
             "version": "5.1.1",
@@ -1161,7 +1090,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
             "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
             "requires": {
                 "semver": "^6.0.0"
             },
@@ -1169,16 +1097,14 @@
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 }
             }
         },
         "make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
         },
         "media-typer": {
             "version": "0.3.0",
@@ -1216,14 +1142,12 @@
         "mimic-response": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "dev": true
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -1231,8 +1155,7 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "ms": {
             "version": "2.1.2",
@@ -1258,7 +1181,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.4.tgz",
             "integrity": "sha512-Ltced+hIfTmaS28Zjv1BM552oQ3dbwPqI4+zI0SLgq+wpJhSyqgYude/aZa/3i31VCQWMfXJVxvu86abcam3uQ==",
-            "dev": true,
             "requires": {
                 "chokidar": "^3.2.2",
                 "debug": "^3.2.6",
@@ -1276,7 +1198,6 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
             "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-            "dev": true,
             "requires": {
                 "abbrev": "1"
             }
@@ -1284,14 +1205,12 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "normalize-url": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-            "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-            "dev": true
+            "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
         },
         "on-finished": {
             "version": "2.3.0",
@@ -1305,7 +1224,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -1313,14 +1231,12 @@
         "p-cancelable": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-            "dev": true
+            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
         },
         "package-json": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
             "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-            "dev": true,
             "requires": {
                 "got": "^9.6.0",
                 "registry-auth-token": "^4.0.0",
@@ -1331,8 +1247,7 @@
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 }
             }
         },
@@ -1349,14 +1264,12 @@
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-            "dev": true
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
         },
         "prepend-http": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-            "dev": true
+            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         },
         "proxy-addr": {
             "version": "2.0.5",
@@ -1370,14 +1283,12 @@
         "pstree.remy": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-            "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-            "dev": true
+            "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
         },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -1392,7 +1303,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
             "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
-            "dev": true,
             "requires": {
                 "escape-goat": "^2.0.0"
             }
@@ -1427,7 +1337,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dev": true,
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -1439,7 +1348,6 @@
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
             "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-            "dev": true,
             "requires": {
                 "picomatch": "^2.2.1"
             }
@@ -1448,7 +1356,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
             "integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
-            "dev": true,
             "requires": {
                 "rc": "^1.2.8"
             }
@@ -1457,7 +1364,6 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
             "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-            "dev": true,
             "requires": {
                 "rc": "^1.2.8"
             }
@@ -1466,7 +1372,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
             "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-            "dev": true,
             "requires": {
                 "lowercase-keys": "^1.0.0"
             }
@@ -1489,14 +1394,12 @@
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "semver-diff": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
             "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-            "dev": true,
             "requires": {
                 "semver": "^6.3.0"
             },
@@ -1504,8 +1407,7 @@
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 }
             }
         },
@@ -1575,8 +1477,7 @@
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "dev": true
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
         "source-map": {
             "version": "0.6.1",
@@ -1601,7 +1502,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
             "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-            "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -1611,26 +1511,22 @@
                 "ansi-regex": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-                    "dev": true
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
                 },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
                 },
                 "strip-ansi": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
                     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.0"
                     }
@@ -1641,7 +1537,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
             "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^4.1.0"
             }
@@ -1649,14 +1544,12 @@
         "strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "dev": true
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "supports-color": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }
@@ -1664,20 +1557,17 @@
         "term-size": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-            "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
-            "dev": true
+            "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
         },
         "to-readable-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-            "dev": true
+            "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
         },
         "to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "requires": {
                 "is-number": "^7.0.0"
             }
@@ -1691,7 +1581,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
             "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-            "dev": true,
             "requires": {
                 "nopt": "~1.0.10"
             }
@@ -1700,7 +1589,6 @@
             "version": "8.10.2",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
             "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
-            "dev": true,
             "requires": {
                 "arg": "^4.1.0",
                 "diff": "^4.0.1",
@@ -1712,8 +1600,7 @@
         "type-fest": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-            "dev": true
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
         },
         "type-is": {
             "version": "1.6.18",
@@ -1728,22 +1615,19 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
         },
         "typescript": {
-            "version": "3.9.7",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-            "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-            "dev": true
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+            "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
         },
         "undefsafe": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
             "integrity": "sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==",
-            "dev": true,
             "requires": {
                 "debug": "^2.2.0"
             },
@@ -1752,7 +1636,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -1760,8 +1643,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -1769,7 +1651,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
             "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-            "dev": true,
             "requires": {
                 "crypto-random-string": "^2.0.0"
             }
@@ -1783,7 +1664,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
             "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
-            "dev": true,
             "requires": {
                 "boxen": "^4.2.0",
                 "chalk": "^3.0.0",
@@ -1813,7 +1693,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
             "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-            "dev": true,
             "requires": {
                 "prepend-http": "^2.0.0"
             }
@@ -1837,7 +1716,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
             "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-            "dev": true,
             "requires": {
                 "string-width": "^4.0.0"
             }
@@ -1845,14 +1723,12 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
             "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-            "dev": true,
             "requires": {
                 "imurmurhash": "^0.1.4",
                 "is-typedarray": "^1.0.0",
@@ -1863,8 +1739,7 @@
         "xdg-basedir": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-            "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-            "dev": true
+            "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
         },
         "xml2js": {
             "version": "0.4.19",
@@ -1888,8 +1763,7 @@
         "yn": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
         }
     }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -12,13 +12,12 @@
         "dynamoose": "^2.3.0",
         "express": "^4.17.1",
         "google-auth-library": "^5.10.1",
-        "uuid": "^3.4.0"
-    },
-    "devDependencies": {
+        "uuid": "^3.4.0",
         "nodemon": "^2.0.4",
         "ts-node": "^8.10.2",
         "typescript": "^3.9.7"
     },
+    "devDependencies": {},
     "scripts": {
         "start": "nodemon --exec \"ts-node\" --watch router --watch models app.ts",
         "tsc": "tsc",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
         "uuid": "^3.4.0",
         "nodemon": "^2.0.4",
         "ts-node": "^8.10.2",
-        "typescript": "^3.9.7"
+        "typescript": "^4.0.3"
     },
     "devDependencies": {},
     "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
         "aws-sdk": "^2.747.0",
         "body-parser": "^1.19.0",
         "dotenv": "^8.2.0",
-        "dynamoose": "^2.2.1",
+        "dynamoose": "^2.3.0",
         "express": "^4.17.1",
         "google-auth-library": "^5.10.1",
         "uuid": "^3.4.0"

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     },
     "scripts": {
         "start": "nodemon --exec \"ts-node\" --watch router --watch models app.ts",
-        "tsc": "tsc --noEmit false",
+        "tsc": "tsc",
         "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/server/router/common.ts
+++ b/server/router/common.ts
@@ -155,19 +155,38 @@ export function query(
   res: Response,
   model: ModelType,
   condition: Condition,
-  index?: string,
+  index: string,
   callback?: (value: any) => void,
 ) {
-  const queryCall = index
-    ? model.query(condition).using(index)
-    : model.query(condition);
-  queryCall.exec((err: any, data: any) => {
-    if (err) {
-      res.send({ err });
-    } else if (callback) {
-      callback(data);
-    } else {
-      res.send({ data });
-    }
-  });
+  model
+    .query(condition)
+    .using(index)
+    .exec((err: any, data: any) => {
+      if (err) {
+        res.send({ err });
+      } else if (callback) {
+        callback(data);
+      } else {
+        res.send({ data });
+      }
+    });
+}
+
+export function scan(
+  res: Response,
+  model: ModelType,
+  condition: Condition,
+  callback?: (value: any) => void,
+) {
+  model
+    .scan(condition)
+    .exec((err, data) => {
+      if (err) {
+        res.send({ err });
+      } else if (callback) {
+        callback(data);
+      } else {
+        res.send({ data });
+      }
+    });
 }

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -6,56 +6,72 @@ import { Ride, Type } from '../models/ride';
 
 const router = express.Router();
 const tableName = 'Rides';
-const typeParam = ':type(active|past|unscheduled)';
 
 // Get a ride by id in Rides table
-router.get(`/${typeParam}/:id`, (req, res) => {
-  const { params: { type, id } } = req;
-  db.getById(res, Ride, { type, id }, tableName);
+router.get('/:id', (req, res) => {
+  const { params: { id } } = req;
+  db.getById(res, Ride, id, tableName);
 });
 
-// Get all rides in Rides table
-router.get('/', (req, res) => db.getAll(res, Ride, tableName));
-
-// Query all rides in table
-router.get(`/${typeParam}`, (req, res) => {
-  const { params: { type }, query: { riderId, driverId, date } } = req;
-  let condition = new Condition('type').eq(type);
-  if (riderId) {
-    condition = condition.where('riderId').eq(riderId);
+// Get and query all rides in table
+router.get('/', (req, res) => {
+  const { query } = req;
+  if (query === {}) {
+    db.getAll(res, Ride, tableName);
+  } else {
+    const { type, rider, driver, date } = query;
+    let condition = new Condition();
+    if (type) {
+      condition = condition.where('type').eq(type);
+    }
+    if (rider) {
+      condition = condition.where('rider').eq(rider);
+    }
+    if (driver) {
+      condition = condition.where('driver').eq(driver);
+    }
+    if (date) {
+      const dateStart = new Date(`${date} EST`).toISOString();
+      const dateEnd = new Date(`${date} 23:59:59.999 EST`).toISOString();
+      condition = condition.where('startTime').between(dateStart, dateEnd);
+    }
+    db.scan(res, Ride, condition);
   }
-  if (driverId) {
-    condition = condition.where('driverId').eq(driverId);
-  }
-  if (date) {
-    const dateStart = new Date(`${date} EST`).toISOString();
-    const dateEnd = new Date(`${date} 23:59:59.999 EST`).toISOString();
-    condition = condition.where('startTime').between(dateStart, dateEnd);
-  }
-  db.query(res, Ride, condition);
 });
 
 // Put an active ride in Active Rides table
 router.post('/', (req, res) => {
-  const { body } = req;
+  const {
+    body: {
+      rider,
+      startLocation,
+      endLocation,
+      startTime,
+      endTime,
+    },
+  } = req;
   const ride = new Ride({
-    type: Type.UNSCHEDULED,
     id: uuid(),
-    ...body,
+    type: Type.UNSCHEDULED,
+    rider,
+    startLocation,
+    endLocation,
+    startTime,
+    endTime,
   });
   db.create(res, ride);
 });
 
 // Update an existing ride
-router.put(`/${typeParam}/:id`, (req, res) => {
-  const { params: { type, id }, body } = req;
-  db.update(res, Ride, { type, id }, body, tableName);
+router.put('/:id', (req, res) => {
+  const { params: { id }, body } = req;
+  db.update(res, Ride, { id }, body, tableName);
 });
 
 // Delete an existing ride
-router.delete(`/${typeParam}/:id`, (req, res) => {
-  const { params: { type, id } } = req;
-  db.deleteById(res, Ride, { type, id }, tableName);
+router.delete('/:id', (req, res) => {
+  const { params: { id } } = req;
+  db.deleteById(res, Ride, id, tableName);
 });
 
 export default router;

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -39,7 +39,7 @@ router.get('/', (req, res) => {
   }
 });
 
-// Put an active ride in Active Rides table
+// Put a ride in Rides table
 router.post('/', (req, res) => {
   const {
     body: {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,8 +14,7 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "resolveJsonModule": true,
-        "isolatedModules": true,
-        "noEmit": true,
+        "isolatedModules": true
     },
     "include": [
         "*"


### PR DESCRIPTION
### Summary <!-- Required -->
This PR updates the ride key schema to only use id instead of id and type. This allows the type of the ride to be changed, and the `/rides` endpoint to handle getting all rides and querying the rides. Models are also added to the Ride schema, allowing a ride's rider, driver, and start and end locations to be accessed with one backend call.

### Test Plan <!-- Required -->
Run the backend and make requests to endpoints for rides.

### Notes <!-- Optional -->
Right now queries are being handled by scanning the database, which will likely get slow once more entries are added to the database. Indexes should be added to the database in a future PR to help speed up the queries. Also Dynamoose support for Typescript is not fully implemented, so models in schema have to be casted to `any`.

### Breaking Changes  <!-- Optional -->
The new rides schema changes and endpoint changes are reflected in the Notion API doc.