### PR TITLE
Add organization (CULift and RedRunner) to Rider schema

### DIFF
--- a/server/models/rider.ts
+++ b/server/models/rider.ts
@@ -6,6 +6,11 @@ export enum Accessibility {
   WHEELCHAIR = 'Wheelchair',
 }
 
+export enum Organization {
+  RED_RUNNER = 'Red_Runner',
+  CULIFT = 'CULift'
+}
+
 export type RiderType = {
   id: string
   firstName: string
@@ -13,6 +18,7 @@ export type RiderType = {
   phoneNumber: string
   email: string
   accessibility: Accessibility[]
+  organization: Organization []
   description: string
   joinDate: string
   pronouns: string
@@ -27,6 +33,10 @@ const schema = new dynamoose.Schema({
   phoneNumber: String,
   email: String,
   accessibility: {
+    type: Array,
+    schema: [String],
+  },
+  organization: {
     type: Array,
     schema: [String],
   },

--- a/server/models/rider.ts
+++ b/server/models/rider.ts
@@ -7,7 +7,7 @@ export enum Accessibility {
 }
 
 export enum Organization {
-  RED_RUNNER = 'Red_Runner',
+  REDRUNNER = 'RedRunner',
   CULIFT = 'CULift'
 }
 
@@ -18,7 +18,7 @@ export type RiderType = {
   phoneNumber: string
   email: string
   accessibility: Accessibility[]
-  organization: Organization []
+  organization: Organization
   description: string
   joinDate: string
   pronouns: string
@@ -37,8 +37,8 @@ const schema = new dynamoose.Schema({
     schema: [String],
   },
   organization: {
-    type: Array,
-    schema: [String],
+    type: String,
+    enum: Object.values(Organization),
   },
   description: String,
   joinDate: String,

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -39,6 +39,15 @@ router.get('/:id/accessibility', async (req, res) => {
   });
 });
 
+// Get organization information for a rider
+router.get('/:id/organization', async (req, res) => {
+  const { params: { id } } = req;
+  db.getById(res, Rider, id, tableName, (rider: RiderType) => {
+    const { description, organization } = rider;
+    res.send({ description, organization });
+  });
+});
+
 // Get all favorite locations for a rider
 router.get('/:id/favorites', (req, res) => {
   const { params: { id } } = req;


### PR DESCRIPTION
### Summary <!-- Required -->
This PR adds the field "Organization" to the Rider schema, represented as a String enum value {'CULift', 'RedRunner'}. CULift indicates a CULift rider and RedRunner is a faculty rider. 
This PR also enables querying by this Organization field.

### Test Plan <!-- Required -->
Run the backend and make requests to rider GET endpoints.

### Breaking Changes  <!-- Optional -->
This database schema change will be reflection in the Notion API doc.
