### PR TITLE
added Ride fields to enable recurring rides

### DIFF
--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -27,6 +27,11 @@ export type RideType = {
   endTime: string,
   rider: RiderType,
   driver?: DriverType,
+  recurring?: boolean,
+  recurringDays?: string[],
+  endDate?: string
+  deleted?: boolean,
+  edits?: string[],
 };
 
 const schema = new dynamoose.Schema({
@@ -48,6 +53,17 @@ const schema = new dynamoose.Schema({
   endTime: String,
   rider: Rider as any,
   driver: Driver as any,
+  recurring: Boolean,
+  recurringDays: {
+    type: Array,
+    schema: [String],
+  },
+  deleted: Boolean,
+  edits: {
+    type: Array,
+    schema: [String],
+  },
+  endDate: String,
 });
 
 export const Ride = dynamoose.model('Rides', schema, { create: false });

--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -28,7 +28,7 @@ export type RideType = {
   rider: RiderType,
   driver?: DriverType,
   recurring?: boolean,
-  recurringDays?: string[],
+  recurringDays?: number[],
   endDate?: string
   deleted?: boolean,
   edits?: string[],
@@ -56,7 +56,7 @@ const schema = new dynamoose.Schema({
   recurring: Boolean,
   recurringDays: {
     type: Array,
-    schema: [String],
+    schema: [Number],
   },
   deleted: Boolean,
   edits: {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds the Rider fields: 
- recurring
- recurringDays
- endDate
- deleted
- edits
in order to enable storing rides that recur once or more per week. This also enables editing and deleting of single instances of a recurring ride without altering the master ride pattern.

### Notes <!-- Optional -->

These fields are optional right now, so that rides can be scheduled as normal without indicating whether they are recurring. 
The design document about how to create, edit, and schedule recurring vs. non-recurring rides is: https://docs.google.com/document/d/1cgifCNPJsfKUSoQMZOpOtb86dVQPACkhIDtp21PYBXA/edit?usp=sharing

### Breaking Changes  <!-- Optional -->

This database schema change will be reflection in the Notion API doc.
