### PR TITLE
Add custom locations to backend

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -129,14 +129,6 @@
             "resolved": "https://registry.npmjs.org/addresser/-/addresser-1.1.19.tgz",
             "integrity": "sha512-H1gn214SFJLfdNnNtQzJ2mWaCQW9JTzAmUftWyuMiyqjpyp2s9YzcMMxHIaFk42eH0PDE2koHQWBPAk7KbFNmA=="
         },
-        "addressit": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/addressit/-/addressit-1.7.0.tgz",
-            "integrity": "sha512-tbyGHuOqxlLy7AWYM9UAraELb6Zguk96gYtltC7+TlhcYRykPLIA0otB9OFosFEft+Qei+PPLPLey1k1LZ+rHA==",
-            "requires": {
-                "cog": "^1.0.0"
-            }
-        },
         "agent-base": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
@@ -435,11 +427,6 @@
             "requires": {
                 "mimic-response": "^1.0.0"
             }
-        },
-        "cog": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/cog/-/cog-1.1.0.tgz",
-            "integrity": "sha1-v/MfgTt96u1a2Gi/42Ty/5r+ELM="
         },
         "color-convert": {
             "version": "2.0.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -124,6 +124,19 @@
                 "negotiator": "0.6.2"
             }
         },
+        "addresser": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/addresser/-/addresser-1.1.19.tgz",
+            "integrity": "sha512-H1gn214SFJLfdNnNtQzJ2mWaCQW9JTzAmUftWyuMiyqjpyp2s9YzcMMxHIaFk42eH0PDE2koHQWBPAk7KbFNmA=="
+        },
+        "addressit": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/addressit/-/addressit-1.7.0.tgz",
+            "integrity": "sha512-tbyGHuOqxlLy7AWYM9UAraELb6Zguk96gYtltC7+TlhcYRykPLIA0otB9OFosFEft+Qei+PPLPLey1k1LZ+rHA==",
+            "requires": {
+                "cog": "^1.0.0"
+            }
+        },
         "agent-base": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
@@ -422,6 +435,11 @@
             "requires": {
                 "mimic-response": "^1.0.0"
             }
+        },
+        "cog": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/cog/-/cog-1.1.0.tgz",
+            "integrity": "sha1-v/MfgTt96u1a2Gi/42Ty/5r+ELM="
         },
         "color-convert": {
             "version": "2.0.1",
@@ -1703,9 +1721,9 @@
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+            "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
         },
         "vary": {
             "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -6,16 +6,18 @@
     "dependencies": {
         "@types/express": "^4.17.8",
         "@types/uuid": "^8.3.0",
+        "addresser": "^1.1.19",
+        "addressit": "^1.7.0",
         "aws-sdk": "^2.747.0",
         "body-parser": "^1.19.0",
         "dotenv": "^8.2.0",
         "dynamoose": "^2.3.0",
         "express": "^4.17.1",
         "google-auth-library": "^5.10.1",
-        "uuid": "^3.4.0",
         "nodemon": "^2.0.4",
         "ts-node": "^8.10.2",
-        "typescript": "^4.0.3"
+        "typescript": "^4.0.3",
+        "uuid": "^8.3.1"
     },
     "devDependencies": {},
     "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,6 @@
         "@types/express": "^4.17.8",
         "@types/uuid": "^8.3.0",
         "addresser": "^1.1.19",
-        "addressit": "^1.7.0",
         "aws-sdk": "^2.747.0",
         "body-parser": "^1.19.0",
         "dotenv": "^8.2.0",

--- a/server/router/common.ts
+++ b/server/router/common.ts
@@ -26,10 +26,6 @@ export function getById(
   });
 }
 
-export function createKeys(property: string, values: string[]) {
-  return values.map((v) => ({ [property]: v }));
-}
-
 export function batchGet(
   res: Response,
   model: ModelType,

--- a/server/router/location.ts
+++ b/server/router/location.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { v4 as uuid } from 'uuid';
 import * as db from './common';
 import { Location } from '../models/location';
+import { formatAddress } from '../util';
 
 const router = express.Router();
 const tableName = 'Locations';
@@ -17,17 +18,22 @@ router.get('/', (req, res) => db.getAll(res, Location, tableName));
 
 // Put a location in Locations table
 router.post('/', (req, res) => {
-  const { body } = req;
+  const { body: { name, address } } = req;
   const location = new Location({
     id: uuid(),
-    ...body,
+    name,
+    address: formatAddress(address),
   });
   db.create(res, location);
 });
 
 // Update an existing location
-router.post('/', (req, res) => {
+router.put('/:id', (req, res) => {
   const { params: { id }, body } = req;
+  const { address } = body;
+  if (address) {
+    body.address = formatAddress(address);
+  }
   db.update(res, Location, { id }, body, tableName);
 });
 

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -90,7 +90,7 @@ router.post('/', (req, res) => {
 router.put('/:id', (req, res) => {
   const { params: { id }, body } = req;
   if (body.type === Type.PAST) {
-    Ride.get(id, (_, ride: any) => {
+    db.getById(res, Ride, id, tableName, (ride) => {
       const {
         startLocation: { id: startId, name: startName },
         endLocation: { id: endId, name: endName },

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -4,6 +4,7 @@ import { Condition } from 'dynamoose';
 import * as db from './common';
 import { Rider, RiderType } from '../models/rider';
 import { Location } from '../models/location';
+import { createKeys } from '../util';
 
 const router = express.Router();
 const tableName = 'Riders';
@@ -43,7 +44,7 @@ router.get('/:id/accessibility', async (req, res) => {
 router.get('/:id/favorites', (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Rider, id, tableName, ({ favoriteLocations }: RiderType) => {
-    const keys = db.createKeys('id', favoriteLocations);
+    const keys = createKeys('id', favoriteLocations);
     db.batchGet(res, Location, keys, 'Locations');
   });
 });
@@ -74,7 +75,7 @@ router.post('/:id/favorites', (req, res) => {
     const condition = new Condition('favoriteLocations').not().contains(locId);
     db.conditionalUpdate(
       res, Rider, { id }, operation, condition, tableName, ({ favoriteLocations }: RiderType) => {
-        const keys = db.createKeys('id', favoriteLocations);
+        const keys = createKeys('id', favoriteLocations);
         db.batchGet(res, Location, keys, 'Locations');
       },
     );

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -1,0 +1,14 @@
+import addresser from 'addresser';
+
+export function createKeys(property: string, values: string[]) {
+  return values.map((v) => ({ [property]: v }));
+}
+
+export function formatAddress(address: string): string {
+  let addressString = address;
+  if (!address.includes(',')) {
+    addressString += ', Ithaca, NY 14850';
+  }
+  // type declaration in addresser is incorrect
+  return (addresser.parseAddress(addressString) as any).formattedAddress;
+}

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -5,10 +5,12 @@ export function createKeys(property: string, values: string[]) {
 }
 
 export function formatAddress(address: string): string {
-  let addressString = address;
-  if (!address.includes(',')) {
-    addressString += ', Ithaca, NY 14850';
+  let addressString;
+  try {
+    // type declaration in addresser is incorrect
+    addressString = parseAddress(address) as any;
+  } catch {
+    addressString = parseAddress(`${address}, Ithaca, NY 14850`) as any;
   }
-  // type declaration in addresser is incorrect
-  return (parseAddress(addressString) as any).formattedAddress;
+  return addressString.formattedAddress;
 }

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -1,4 +1,4 @@
-import addresser from 'addresser';
+import { parseAddress } from 'addresser';
 
 export function createKeys(property: string, values: string[]) {
   return values.map((v) => ({ [property]: v }));
@@ -10,5 +10,5 @@ export function formatAddress(address: string): string {
     addressString += ', Ithaca, NY 14850';
   }
   // type declaration in addresser is incorrect
-  return (addresser.parseAddress(addressString) as any).formattedAddress;
+  return (parseAddress(addressString) as any).formattedAddress;
 }


### PR DESCRIPTION
### Summary <!-- Required -->
This PR adds the ability to add custom locations for rides to the database. On ride creation, if a location is custom, a new location will be created. When a ride changes to past, the custom locations in the ride will be deleted and replaced with a location named "Custom".

Additional changes include a util file with reusable functions not relating to database operations, and fixing an error with the update locations endpoint.

### Test Plan <!-- Required -->
Create a ride with a custom location, check Locations table to make sure location was created, update ride type to past, verify locations have been deleted and replaced with "Custom".

### Breaking Changes  <!-- Optional -->
`startLocation` and `endLocation` can be in two formats:
- No city, state, and zipcode; assumed in Ithaca: 123 Main Street or 123 Main Street, Apartment 2
- Any city, state, and zipcode: 123 Main Street, Ithaca, NY 14850