### PR TITLE
Prevent ids from being assigned through request

### DIFF
--- a/server/router/dispatcher.ts
+++ b/server/router/dispatcher.ts
@@ -11,7 +11,7 @@ router.post('/', (req, res) => {
   const { body } = req;
   const dispatcher = new Dispatcher({
     ...body,
-    id: uuid(),
+    id: uuid()
   });
   db.create(res, dispatcher);
 });

--- a/server/router/dispatcher.ts
+++ b/server/router/dispatcher.ts
@@ -10,8 +10,8 @@ const tableName = 'Dispatchers';
 router.post('/', (req, res) => {
   const { body } = req;
   const dispatcher = new Dispatcher({
-    id: uuid(),
     ...body,
+    id: uuid(),
   });
   db.create(res, dispatcher);
 });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -33,7 +33,7 @@ router.post('/', (req, res) => {
   const { body } = req;
   const driver = new Driver({
     ...body,
-    id: uuid(),
+    id: uuid()
   });
   db.create(res, driver);
 });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -32,8 +32,8 @@ router.get('/:id/profile', (req, res) => {
 router.post('/', (req, res) => {
   const { body } = req;
   const driver = new Driver({
-    id: uuid(),
     ...body,
+    id: uuid(),
   });
   db.create(res, driver);
 });

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -62,8 +62,8 @@ router.get('/:id/favorites', (req, res) => {
 router.post('/', (req, res) => {
   const { body } = req;
   const rider = new Rider({
-    id: uuid(),
     ...body,
+    id: uuid(),
     favoriteLocations: [],
   });
   db.create(res, rider);

--- a/server/router/vehicle.ts
+++ b/server/router/vehicle.ts
@@ -20,7 +20,7 @@ router.post('/', (req, res) => {
   const { body } = req;
   const vehicle = new Vehicle({
     ...body,
-    id: uuid(),
+    id: uuid()
   });
   db.create(res, vehicle);
 });

--- a/server/router/vehicle.ts
+++ b/server/router/vehicle.ts
@@ -19,8 +19,8 @@ router.get('/', (req, res) => db.getAll(res, Vehicle, tableName));
 router.post('/', (req, res) => {
   const { body } = req;
   const vehicle = new Vehicle({
-    id: uuid(),
     ...body,
+    id: uuid(),
   });
   db.create(res, vehicle);
 });


### PR DESCRIPTION
### Summary <!-- Required -->
This PR moves all id assignment after any `body` destructuring in a POST request handler, preventing the ability for users to assign a custom id to a new model.

### Test Plan <!-- Required -->
Create a new rider, driver, dispatcher, and vehicle, and in the body try to set a custom `id`.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
