### PR TITLE
Replace driver startTime, endTime, and breaks with availability

### DIFF
--- a/server/models/driver.ts
+++ b/server/models/driver.ts
@@ -1,56 +1,52 @@
 import dynamoose from 'dynamoose';
 import { Vehicle, VehicleType } from './vehicle';
 
-type BreakTimes = {
-  breakStart: string,
-  breakEnd: string,
+type Availability = {
+  startTime: string,
+  endTime: string,
 }
 
-type BreakType = {
-  Mon?: BreakTimes,
-  Tue?: BreakTimes,
-  Wed?: BreakTimes,
-  Thu?: BreakTimes,
-  Fri?: BreakTimes,
+type AvailabilityType = {
+  Mon?: Availability,
+  Tue?: Availability,
+  Wed?: Availability,
+  Thu?: Availability,
+  Fri?: Availability,
 }
 
 export type DriverType = {
   id: string,
   firstName: string,
   lastName: string,
-  startTime: string,
-  endTime: string,
-  breaks: BreakType,
+  availability: AvailabilityType,
   vehicle: VehicleType,
   phoneNumber: string,
   email: string,
 };
 
-const breakDayValue = {
+const availability = {
   type: Object,
   schema: {
-    breakStart: String,
-    breakEnd: String,
+    startTime: String,
+    endTime: String,
   },
 };
 
-const breakSchema = {
-  Mon: breakDayValue,
-  Tue: breakDayValue,
-  Wed: breakDayValue,
-  Thu: breakDayValue,
-  Fri: breakDayValue,
+const availabilitySchema = {
+  Mon: availability,
+  Tue: availability,
+  Wed: availability,
+  Thu: availability,
+  Fri: availability,
 };
 
 const schema = new dynamoose.Schema({
   id: String,
   firstName: String,
   lastName: String,
-  startTime: String,
-  endTime: String,
-  breaks: {
+  availability: {
     type: Object,
-    schema: breakSchema,
+    schema: availabilitySchema,
   },
   vehicle: Vehicle as any,
   phoneNumber: String,

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -20,10 +20,10 @@ router.get('/:id/profile', (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Driver, id, tableName, (driver: DriverType) => {
     const {
-      email, firstName, lastName, phoneNumber, startTime, endTime, breaks, vehicle,
+      email, firstName, lastName, phoneNumber, availability, vehicle,
     } = driver;
     res.send({
-      email, firstName, lastName, phoneNumber, startTime, endTime, breaks, vehicle,
+      email, firstName, lastName, phoneNumber, availability, vehicle,
     });
   });
 });


### PR DESCRIPTION
### Summary <!-- Required -->
This PR removes the `startTime`, `endTime`, and `breaks` properties of a driver, and replaces them with `availability`. `availability` is structured similar to `breaks`, where it is a map consisting of (optional) keys Mon, Tue, Wed, Thu, Fri, and values of the form `{ startTime: string, endTime: string }`.  If a driver isn't available for a certain day, that day will not be included in `availability`.

### Test Plan <!-- Required -->
Create a new driver, following the new schema.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->
As mentioned before, `startTime`, `endTime`, and `breaks` are being removed from the Driver schema, so they are no longer supported. All changes are reflected in the API documentation.