### PR TITLE
Fix driver cards rendering

### DIFF
--- a/frontend/src/components/DriverCards/DriverCards.tsx
+++ b/frontend/src/components/DriverCards/DriverCards.tsx
@@ -13,7 +13,7 @@ const formatTime = (time: string) => {
 };
 
 const formatAvailability = (availability: AvailabilityType) => {
-  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const availabilityList = days.reduce((acc, day) => {
     const availabilityTimes = availability[day];
     if (availabilityTimes) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,23 +17,21 @@ export type Rider = {
   address: string;
 };
 
-export type BreakTimes = {
-  breakStart: string;
-  breakEnd: string;
+export type Availability = {
+  startTime: string;
+  endTime: string;
 };
 
-export type BreakType = {
-  [day: string]: BreakTimes;
+export type AvailabilityType = {
+  [day: string]: Availability;
 };
 
 export type Driver = {
   id: string;
   firstName: string;
   lastName: string;
-  startTime: string;
-  endTime: string;
-  breaks: BreakType;
-  vehicle: string;
+  availability: AvailabilityType;
+  vehicle: Vehicle;
   phoneNumber: string;
   email: string;
   phone: string;


### PR DESCRIPTION
### Summary <!-- Required -->
With the new changes to the Driver model in the backend, rendering the cards results in errors. This PR fixes this issue by replacing deprecated fields `startTime`, `endTime`, and `breaks` with `availability`, as well as removing vehicle fetching as that is handled by the backend now.

### Test Plan <!-- Required -->
![](https://imgur.com/FfL1XJ0.jpg)
Run the frontend and navigate to the Drivers tab on the sidebar.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
