### PR TITLE
connected unscheduled rides to backend

### DIFF
--- a/frontend/src/components/Modal/AssignDriverModal.tsx
+++ b/frontend/src/components/Modal/AssignDriverModal.tsx
@@ -7,12 +7,12 @@ type AssignModalProps = {
   close: () => void;
   ride: RealRide;
   allDrivers: Driver[];
-}
+};
 
 type DriverRowProps = {
   firstName: string;
   imageURL: string;
-}
+};
 
 const DriverRow = ({ firstName, imageURL }: DriverRowProps) => (
   <div className={styles.driverRow}>
@@ -21,7 +21,12 @@ const DriverRow = ({ firstName, imageURL }: DriverRowProps) => (
   </div>
 );
 
-const AssignDriverModal = ({ isOpen, close, ride, allDrivers }: AssignModalProps) => {
+const AssignDriverModal = ({
+  isOpen,
+  close,
+  ride,
+  allDrivers,
+}: AssignModalProps) => {
   // source: https://stackoverflow.com/questions/32553158/detect-click-outside-react-component
   function useOutsideAlerter(ref: any) {
     useEffect(() => {
@@ -38,18 +43,23 @@ const AssignDriverModal = ({ isOpen, close, ride, allDrivers }: AssignModalProps
     }, [ref]);
   }
 
-
   const wrapperRef = useRef(null);
   useOutsideAlerter(wrapperRef);
 
   return (
     <>
-      {isOpen
-        && <div className={styles.modal} ref={wrapperRef}>
+      {isOpen && (
+        <div className={styles.modal} ref={wrapperRef}>
           <h1 className={styles.titleText}>Available Drivers</h1>
-        {allDrivers.map((driver, id) => <DriverRow key={id} firstName={driver.firstName} imageURL='https://www.biography.com/.image/t_share/MTE5NDg0MDYwNjkzMjY3OTgz/terry-crews-headshot-600x600jpg.jpg' />)}
+          {allDrivers.map((driver, id) => (
+            <DriverRow
+              key={id}
+              firstName={driver.firstName}
+              imageURL="https://www.biography.com/.image/t_share/MTE5NDg0MDYwNjkzMjY3OTgz/terry-crews-headshot-600x600jpg.jpg"
+            />
+          ))}
         </div>
-      }
+      )}
     </>
   );
 };

--- a/frontend/src/components/Modal/AssignDriverModal.tsx
+++ b/frontend/src/components/Modal/AssignDriverModal.tsx
@@ -1,11 +1,11 @@
 import React, { useRef, useEffect } from 'react';
-import { Passenger, Driver } from '../../types/index';
+import { RealRide, Driver } from '../../types/index';
 import styles from './assigndrivermodal.module.css';
 
 type AssignModalProps = {
   isOpen: boolean;
   close: () => void;
-  ride: Passenger;
+  ride: RealRide;
   allDrivers: Driver[];
 }
 
@@ -47,7 +47,7 @@ const AssignDriverModal = ({ isOpen, close, ride, allDrivers }: AssignModalProps
       {isOpen
         && <div className={styles.modal} ref={wrapperRef}>
           <h1 className={styles.titleText}>Available Drivers</h1>
-          {allDrivers.map((driver) => <DriverRow firstName={driver.firstName} imageURL='https://www.biography.com/.image/t_share/MTE5NDg0MDYwNjkzMjY3OTgz/terry-crews-headshot-600x600jpg.jpg' />)}
+        {allDrivers.map((driver, id) => <DriverRow key={id} firstName={driver.firstName} imageURL='https://www.biography.com/.image/t_share/MTE5NDg0MDYwNjkzMjY3OTgz/terry-crews-headshot-600x600jpg.jpg' />)}
         </div>
       }
     </>

--- a/frontend/src/components/Modal/AssignDriverModal.tsx
+++ b/frontend/src/components/Modal/AssignDriverModal.tsx
@@ -1,11 +1,11 @@
 import React, { useRef, useEffect } from 'react';
-import { RealRide, Driver } from '../../types/index';
+import { Ride, Driver } from '../../types/index';
 import styles from './assigndrivermodal.module.css';
 
 type AssignModalProps = {
   isOpen: boolean;
   close: () => void;
-  ride: RealRide;
+  ride: Ride;
   allDrivers: Driver[];
 };
 

--- a/frontend/src/components/UserTables/UnscheduledTable.tsx
+++ b/frontend/src/components/UserTables/UnscheduledTable.tsx
@@ -18,8 +18,8 @@ function renderTableHeader() {
 }
 
 type TableProps = {
-  drivers: Driver[]
-}
+  drivers: Driver[];
+};
 const Table = ({ drivers }: TableProps) => {
   const [openModal, setOpenModal] = useState(-1);
   const [rides, setRides] = useState<RealRide[]>([]);
@@ -33,51 +33,69 @@ const Table = ({ drivers }: TableProps) => {
   };
 
   const getUnscheduledRides = () => {
-    fetch('/rides?type=unscheduled').then((res) => res.json()).then(({ data }) => setRides(data.sort(compRides)));
+    fetch('/rides?type=unscheduled')
+      .then((res) => res.json())
+      .then(({ data }) => setRides(data.sort(compRides)));
   };
 
   useEffect(getUnscheduledRides, []);
 
   function renderTableData(allRides: RealRide[]) {
     return allRides.map((ride, index) => {
-      const startTime = (new Date(ride.startTime)).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-      const endTime = (new Date(ride.endTime)).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const startTime = new Date(ride.startTime).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      const endTime = new Date(ride.endTime).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
       const { rider } = ride;
-      const name = (rider) ? `${rider.firstName} ${rider.lastName}` : '';
-      const needs = (rider) ? (rider.accessibilityNeeds || []).join(', ') : '';
+      const name = rider ? `${rider.firstName} ${rider.lastName}` : '';
+      const needs = rider ? (rider.accessibilityNeeds || []).join(', ') : '';
       const pickupLocation = ride.startLocation.name;
       const pickupTag = ride.startLocation.tag;
-      console.log(pickupTag);
       const dropoffLocation = ride.endLocation.name;
       const dropoffTag = ride.endLocation.tag;
 
-
-      const timeframe = (new Date(ride.startTime)).toLocaleString('en-US', { hour: 'numeric', hour12: true });
+      const timeframe = new Date(ride.startTime).toLocaleString('en-US', {
+        hour: 'numeric',
+        hour12: true,
+      });
       const valueName = { data: name };
       const valuePickup = { data: pickupLocation, tag: pickupTag };
       const valueDropoff = { data: dropoffLocation, tag: dropoffTag };
       const valueNeeds = { data: needs };
-      const assignModal = () => <AssignDriverModal
-        isOpen={openModal === index}
-        close={() => setOpenModal(-1)}
-        ride={rides[0]}
-        allDrivers={drivers} />;
-
+      const assignModal = () => (
+        <AssignDriverModal
+          isOpen={openModal === index}
+          close={() => setOpenModal(-1)}
+          ride={rides[0]}
+          allDrivers={drivers}
+        />
+      );
 
       const assignButton = {
         data: 'Assign',
         buttonHandler: () => setOpenModal(index),
         ButtonModal: assignModal,
       };
-      const inputValues = [valueName, valuePickup, valueDropoff, valueNeeds, assignButton];
+      const inputValues = [
+        valueName,
+        valuePickup,
+        valueDropoff,
+        valueNeeds,
+        assignButton,
+      ];
       return (
         <tr key={index}>
           <td className={styles.cell}>{timeframe}</td>
           <td className={styles.cell}>
             <span className={styles.bold}>{startTime}</span> <br></br>
-            <span className={styles.gray}>-- {endTime}</span></td>
+            <span className={styles.gray}>-- {endTime}</span>
+          </td>
           <TableRow values={inputValues} />
-        </tr >
+        </tr>
       );
     });
   }
@@ -86,7 +104,7 @@ const Table = ({ drivers }: TableProps) => {
     <>
       <div>
         <h1 className={styles.formHeader}>Unscheduled Rides</h1>
-        <table cellSpacing='0' className={styles.table} >
+        <table cellSpacing="0" className={styles.table}>
           <tbody>
             {renderTableHeader()}
             {renderTableData(rides)}

--- a/frontend/src/components/UserTables/UnscheduledTable.tsx
+++ b/frontend/src/components/UserTables/UnscheduledTable.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Driver, RealRide } from '../../types/index';
+import moment from 'moment';
+import { Driver, Ride } from '../../types/index';
 import styles from './table.module.css';
 import TableRow from '../TableComponents/TableRow';
 import AssignDriverModal from '../Modal/AssignDriverModal';
@@ -22,9 +23,9 @@ type TableProps = {
 };
 const Table = ({ drivers }: TableProps) => {
   const [openModal, setOpenModal] = useState(-1);
-  const [rides, setRides] = useState<RealRide[]>([]);
+  const [rides, setRides] = useState<Ride[]>([]);
 
-  const compRides = (a: RealRide, b: RealRide) => {
+  const compRides = (a: Ride, b: Ride) => {
     const x = new Date(a.startTime);
     const y = new Date(b.startTime);
     if (x < y) return -1;
@@ -33,14 +34,15 @@ const Table = ({ drivers }: TableProps) => {
   };
 
   const getUnscheduledRides = () => {
-    fetch('/rides?type=unscheduled')
+    const today = moment(new Date()).format('YYYY-MM-DD');
+    fetch(`/rides?type=unscheduled&date=${today}`)
       .then((res) => res.json())
       .then(({ data }) => setRides(data.sort(compRides)));
   };
 
   useEffect(getUnscheduledRides, []);
 
-  function renderTableData(allRides: RealRide[]) {
+  function renderTableData(allRides: Ride[]) {
     return allRides.map((ride, index) => {
       const startTime = new Date(ride.startTime).toLocaleTimeString([], {
         hour: '2-digit',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -75,20 +75,22 @@ export type Location = {
   tag?: Tag;
 };
 
-export type Passenger = {
-  startTime: string;
-  endTime: string;
-  name: string;
-  pickupLocation: string;
-  pickupTag: string;
-  dropoffLocation: string;
-  dropoffTag: string;
-  needs: string;
-};
-
 export type TableValue = {
   data: string | null;
   tag?: string;
   buttonHandler?: () => void;
   ButtonModal?: () => JSX.Element;
+};
+
+export type RealRide = {
+  id: string;
+  type: string;
+  status: string;
+  late?: boolean;
+  startLocation: Location;
+  endLocation: Location;
+  startTime: string;
+  endTime: string;
+  rider: Rider;
+  driver?: Driver;
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -39,16 +39,6 @@ export type Driver = {
   phone: string;
 };
 
-export type Ride = {
-  type: string;
-  id: string;
-  startLocation: string;
-  endLocation: string;
-  startTime: string;
-  endTime: string;
-  riderId: string;
-};
-
 export type ObjectType = {
   [x: string]: any;
 }
@@ -82,7 +72,7 @@ export type TableValue = {
   ButtonModal?: () => JSX.Element;
 };
 
-export type RealRide = {
+export type Ride = {
   id: string;
   type: string;
   status: string;


### PR DESCRIPTION
### Summary <!-- Required -->

Set data from `/rides?type=unscheduled` to be displayed on the unscheduled rides table on the home page.

![image](https://user-images.githubusercontent.com/52215742/100527862-a22a2280-31a4-11eb-9a56-4547d8ef4e06.png)

### Test Plan <!-- Required -->

View home page.

### Notes <!-- Optional -->

Fixed an issue with `AssignDriverModal` missing keys.

~~The type for rides is called `RealRide` as there was already a ride type defined, which I'm assuming was used for adding rides.~~
There are many broken rides with invalid data.

### Breaking Changes

The type `Ride` was changed since it was defined but never used elsewhere.