### PR TITLE
Create middleware to add endpoint authentication

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -60,6 +60,14 @@
                 "@types/range-parser": "*"
             }
         },
+        "@types/jsonwebtoken": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+            "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/mime": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1043,6 +1043,44 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
             "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
         },
+        "jsonwebtoken": {
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+            "requires": {
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^5.6.0"
+            },
+            "dependencies": {
+                "jwa": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+                    "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+                    "requires": {
+                        "buffer-equal-constant-time": "1.0.1",
+                        "ecdsa-sig-formatter": "1.0.11",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "jws": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+                    "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+                    "requires": {
+                        "jwa": "^1.4.1",
+                        "safe-buffer": "^5.0.1"
+                    }
+                }
+            }
+        },
         "jwa": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -1077,6 +1115,41 @@
             "requires": {
                 "package-json": "^6.3.0"
             }
+        },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "lowercase-keys": {
             "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
         "dynamoose": "^2.3.0",
         "express": "^4.17.1",
         "google-auth-library": "^5.10.1",
+        "jsonwebtoken": "^8.5.1",
         "nodemon": "^2.0.4",
         "ts-node": "^8.10.2",
         "typescript": "^4.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
     "main": "app.js",
     "dependencies": {
         "@types/express": "^4.17.8",
+        "@types/jsonwebtoken": "^8.5.0",
         "@types/uuid": "^8.3.0",
         "addresser": "^1.1.19",
         "aws-sdk": "^2.747.0",

--- a/server/router/auth.ts
+++ b/server/router/auth.ts
@@ -5,7 +5,7 @@ import jwt from 'jsonwebtoken';
 import { ModelType } from 'dynamoose/dist/General';
 import { Document } from 'dynamoose/dist/Document';
 import { Rider } from '../models/rider';
-import { Dispatcher, DispatcherType } from '../models/dispatcher';
+import { Dispatcher } from '../models/dispatcher';
 import { Driver } from '../models/driver';
 
 const router = express.Router();

--- a/server/router/auth.ts
+++ b/server/router/auth.ts
@@ -18,7 +18,6 @@ const validIds = [
   '346199868830-dfi7n737u4g6ajl3ketot11d1m3n1sr3.apps.googleusercontent.com',
   '322014396101-8u88pc3q00v6dre4doa64psr9349bhum.apps.googleusercontent.com',
   '241748771473-0r3v31qcthi2kj09e5qk96mhsm5omrvr.apps.googleusercontent.com',
-  '407408718192.apps.googleusercontent.com', // remove when done
 ];
 
 async function verify(clientId: string, token: string): Promise<LoginTicket> {

--- a/server/router/auth.ts
+++ b/server/router/auth.ts
@@ -39,10 +39,7 @@ function getModel(table: string) {
   return tableToModel[table];
 }
 
-function getUserType(table: string, user: any) {
-  if (table === 'Dispatchers') {
-    return (user as DispatcherType).accessLevel;
-  }
+function getUserType(table: string) {
   return table.slice(0, table.length - 1);
 }
 
@@ -62,7 +59,7 @@ router.post('/', (req, res) => {
             const user: any = data[0];
             const userPayload = {
               id: user ? user.id : null,
-              userType: getUserType(table, user),
+              userType: getUserType(table),
             };
             res.send({ jwt: jwt.sign(userPayload, process.env.JWT_SECRET!) });
           } else {

--- a/server/router/auth.ts
+++ b/server/router/auth.ts
@@ -39,7 +39,7 @@ function getModel(table: string) {
   return tableToModel[table];
 }
 
-function getRole(table: string, user: any) {
+function getUserType(table: string, user: any) {
   if (table === 'Dispatchers') {
     return (user as DispatcherType).accessLevel;
   }
@@ -62,7 +62,7 @@ router.post('/', (req, res) => {
             const user: any = data[0];
             const userPayload = {
               id: user ? user.id : null,
-              userType: getRole(table, user),
+              userType: getUserType(table, user),
             };
             res.send({ jwt: jwt.sign(userPayload, process.env.JWT_SECRET!) });
           } else {

--- a/server/router/auth.ts
+++ b/server/router/auth.ts
@@ -1,13 +1,14 @@
 import { OAuth2Client } from 'google-auth-library';
 import { LoginTicket } from 'google-auth-library/build/src/auth/loginticket';
 import express from 'express';
-import AWS from 'aws-sdk';
-import config from '../config';
+import jwt from 'jsonwebtoken';
+import { ModelType } from 'dynamoose/dist/General';
+import { Document } from 'dynamoose/dist/Document';
+import { Rider } from '../models/rider';
+import { Dispatcher, DispatcherType } from '../models/dispatcher';
+import { Driver } from '../models/driver';
 
 const router = express.Router();
-
-AWS.config.update(config);
-const docClient = new AWS.DynamoDB.DocumentClient();
 
 const validIds = [
   '322014396101-q7vtrj4rg7h8tlknl1gati2lkbdbu3sp.apps.googleusercontent.com',
@@ -17,6 +18,7 @@ const validIds = [
   '346199868830-dfi7n737u4g6ajl3ketot11d1m3n1sr3.apps.googleusercontent.com',
   '322014396101-8u88pc3q00v6dre4doa64psr9349bhum.apps.googleusercontent.com',
   '241748771473-0r3v31qcthi2kj09e5qk96mhsm5omrvr.apps.googleusercontent.com',
+  '407408718192.apps.googleusercontent.com', // remove when done
 ];
 
 async function verify(clientId: string, token: string): Promise<LoginTicket> {
@@ -28,35 +30,52 @@ async function verify(clientId: string, token: string): Promise<LoginTicket> {
   return authRes;
 }
 
+function getModel(table: string) {
+  const tableToModel: { [table: string]: ModelType<Document> } = {
+    Riders: Rider,
+    Drivers: Driver,
+    Dispatchers: Dispatcher,
+  };
+  return tableToModel[table];
+}
+
+function getRole(table: string, user: any) {
+  if (table === 'Dispatchers') {
+    return (user as DispatcherType).accessLevel;
+  }
+  return table.slice(0, table.length - 1);
+}
+
 // Verify an authentication token
 router.post('/', (req, res) => {
   const { token, clientId, table, email } = req.body;
   verify(clientId, token)
     .then((authRes) => {
       const payload = authRes.getPayload();
-      const validTable = ['Riders', 'Drivers', 'Dispatchers'];
-      if (payload && payload.aud === clientId && validTable.includes(table)) {
-        const params = {
-          TableName: table,
-          ProjectionExpression: 'id, email',
-          FilterExpression: 'email = :user_email',
-          ExpressionAttributeValues: {
-            ':user_email': email,
-          },
-        };
-        docClient.scan(params, (err, data) => {
+      const model = getModel(table);
+      if (payload && payload.aud === clientId && model) {
+        model.scan({ email: { eq: email } }).exec((err, data) => {
           if (err) {
-            res.send({ err });
+            res.send({ err: err.message });
+          } else if (data) {
+            // Dynamoose type is incorrect
+            const user: any = data[0];
+            const userPayload = {
+              id: user ? user.id : null,
+              userType: getRole(table, user),
+            };
+            res.send({ jwt: jwt.sign(userPayload, process.env.JWT_SECRET!) });
           } else {
-            const userList = data.Items;
-            res.send({ id: data.Count ? userList![0].id : null });
+            res.send({ success: false });
           }
         });
       } else {
         res.send({ success: false });
       }
     })
-    .catch(() => res.send({ success: false }));
+    .catch(() => {
+      res.send({ success: false });
+    });
 });
 
 export default router;

--- a/server/router/common.ts
+++ b/server/router/common.ts
@@ -1,14 +1,11 @@
 import { Response } from 'express';
-import { Model } from 'dynamoose/dist/Model';
 import { Document } from 'dynamoose/dist/Document';
-import { ObjectType } from 'dynamoose/dist/General';
+import { ModelType, ObjectType } from 'dynamoose/dist/General';
 import { Condition } from 'dynamoose/dist/Condition';
-
-type ModelType = Document & Model<Document>;
 
 export function getById(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   id: string | ObjectType,
   table: string,
   callback?: (value: any) => void,
@@ -28,7 +25,7 @@ export function getById(
 
 export function batchGet(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   keys: ObjectType[],
   table: string,
   callback?: (value: any) => void,
@@ -51,7 +48,7 @@ export function batchGet(
 
 export function getAll(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   table: string,
   callback?: (value: any) => void,
 ) {
@@ -86,7 +83,7 @@ export function create(
 
 export function update(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   key: ObjectType,
   operation: ObjectType,
   table: string,
@@ -107,7 +104,7 @@ export function update(
 
 export function conditionalUpdate(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   key: ObjectType,
   operation: ObjectType,
   condition: Condition,
@@ -129,7 +126,7 @@ export function conditionalUpdate(
 
 export function deleteById(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   id: string | ObjectType,
   table: string,
   callback?: (value: any) => void,
@@ -149,7 +146,7 @@ export function deleteById(
 
 export function query(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   condition: Condition,
   index: string,
   callback?: (value: any) => void,
@@ -170,7 +167,7 @@ export function query(
 
 export function scan(
   res: Response,
-  model: ModelType,
+  model: ModelType<Document>,
   condition: Condition,
   callback?: (value: any) => void,
 ) {

--- a/server/router/dispatcher.ts
+++ b/server/router/dispatcher.ts
@@ -8,7 +8,9 @@ const router = express.Router();
 const tableName = 'Dispatchers';
 
 // Get all dispatchers
-router.get('/', (req, res) => db.getAll(res, Dispatcher, tableName));
+router.get('/', validateUser('Dispatcher'), (req, res) => {
+  db.getAll(res, Dispatcher, tableName);
+});
 
 // Put a driver in Dispatchers table
 router.post('/', validateUser('Dispatcher'), (req, res) => {

--- a/server/router/dispatcher.ts
+++ b/server/router/dispatcher.ts
@@ -2,22 +2,23 @@ import express from 'express';
 import { v4 as uuid } from 'uuid';
 import * as db from './common';
 import { Dispatcher } from '../models/dispatcher';
+import { validateUser } from '../util';
 
 const router = express.Router();
 const tableName = 'Dispatchers';
 
 // Put a driver in Dispatchers table
-router.post('/', (req, res) => {
+router.post('/', validateUser('Dispatcher'), (req, res) => {
   const { body } = req;
   const dispatcher = new Dispatcher({
     ...body,
-    id: uuid()
+    id: uuid(),
   });
   db.create(res, dispatcher);
 });
 
 // Remove Dispatcher
-router.delete('/:id', (req, res) => {
+router.delete('/:id', validateUser('Dispatcher'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Dispatcher, id, tableName);
 });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -33,7 +33,7 @@ router.post('/', (req, res) => {
   const { body } = req;
   const driver = new Driver({
     ...body,
-    id: uuid()
+    id: uuid(),
   });
   db.create(res, driver);
 });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -2,21 +2,24 @@ import express from 'express';
 import { v4 as uuid } from 'uuid';
 import * as db from './common';
 import { Driver, DriverType } from '../models/driver';
+import { validateUser } from '../util';
 
 const router = express.Router();
 const tableName = 'Drivers';
 
 // Get a driver by id in Drivers table
-router.get('/:id', (req, res) => {
+router.get('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Driver, id, tableName);
 });
 
 // Get all drivers
-router.get('/', (req, res) => db.getAll(res, Driver, tableName));
+router.get('/', validateUser('User'), (req, res) => {
+  db.getAll(res, Driver, tableName);
+});
 
 // Get profile information for a driver
-router.get('/:id/profile', (req, res) => {
+router.get('/:id/profile', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Driver, id, tableName, (driver: DriverType) => {
     const {
@@ -29,7 +32,7 @@ router.get('/:id/profile', (req, res) => {
 });
 
 // Put a driver in Drivers table
-router.post('/', (req, res) => {
+router.post('/', validateUser('Driver'), (req, res) => {
   const { body } = req;
   const driver = new Driver({
     ...body,
@@ -39,13 +42,13 @@ router.post('/', (req, res) => {
 });
 
 // Update an existing driver
-router.put('/:id', (req, res) => {
+router.put('/:id', validateUser('Driver'), (req, res) => {
   const { params: { id }, body } = req;
   db.update(res, Driver, { id }, body, tableName);
 });
 
 // Delete an existing driver
-router.delete('/:id', (req, res) => {
+router.delete('/:id', validateUser('Driver'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Driver, id, tableName);
 });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import { v4 as uuid } from 'uuid';
-import jwt from 'jsonwebtoken';
 import * as db from './common';
 import { Driver, DriverType } from '../models/driver';
 import { validateUser } from '../util';
@@ -15,7 +14,7 @@ router.get('/:id', validateUser('User'), (req, res) => {
 });
 
 // Get all drivers
-router.get('/', validateUser('User'), (req, res) => {
+router.get('/', validateUser('Dispatcher'), (req, res) => {
   db.getAll(res, Driver, tableName);
 });
 
@@ -33,23 +32,13 @@ router.get('/:id/profile', validateUser('User'), (req, res) => {
 });
 
 // Put a driver in Drivers table
-router.post('/', validateUser('Driver'), (req, res) => {
+router.post('/', validateUser('Dispatcher'), (req, res) => {
   const { body } = req;
   const driver = new Driver({
     ...body,
     id: uuid(),
   });
-  db.create(res, driver, (data: DriverType) => {
-    const { locals: { user: { id } } } = res;
-    if (id) {
-      res.send(data);
-    } else {
-      res.send({
-        ...data,
-        jwt: jwt.sign({ id: data.id, userType: 'Driver' }, process.env.JWT_SECRET!),
-      });
-    }
-  });
+  db.create(res, driver);
 });
 
 // Update an existing driver
@@ -59,7 +48,7 @@ router.put('/:id', validateUser('Driver'), (req, res) => {
 });
 
 // Delete an existing driver
-router.delete('/:id', validateUser('Driver'), (req, res) => {
+router.delete('/:id', validateUser('Dispatcher'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Driver, id, tableName);
 });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { v4 as uuid } from 'uuid';
+import jwt from 'jsonwebtoken';
 import * as db from './common';
 import { Driver, DriverType } from '../models/driver';
 import { validateUser } from '../util';
@@ -38,7 +39,17 @@ router.post('/', validateUser('Driver'), (req, res) => {
     ...body,
     id: uuid(),
   });
-  db.create(res, driver);
+  db.create(res, driver, (data: DriverType) => {
+    const { locals: { user: { id } } } = res;
+    if (id) {
+      res.send(data);
+    } else {
+      res.send({
+        ...data,
+        jwt: jwt.sign({ id: data.id, userType: 'Driver' }, process.env.JWT_SECRET!),
+      });
+    }
+  });
 });
 
 // Update an existing driver

--- a/server/router/location.ts
+++ b/server/router/location.ts
@@ -3,19 +3,19 @@ import { v4 as uuid } from 'uuid';
 import { Condition } from 'dynamoose/dist/Condition';
 import * as db from './common';
 import { Location, Tag } from '../models/location';
-import { formatAddress } from '../util';
+import { formatAddress, validateUser } from '../util';
 
 const router = express.Router();
 const tableName = 'Locations';
 
 // Get a location by id in Locations table
-router.get('/:id', (req, res) => {
+router.get('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Location, id, tableName);
 });
 
 // Get and query all locations
-router.get('/', (req, res) => {
+router.get('/', validateUser('User'), (req, res) => {
   const { query } = req;
   if (query === {}) {
     db.getAll(res, Location, tableName);
@@ -42,7 +42,7 @@ router.get('/', (req, res) => {
 });
 
 // Put a location in Locations table
-router.post('/', (req, res) => {
+router.post('/', validateUser('Dispatcher'), (req, res) => {
   const { body: { name, address } } = req;
   const location = new Location({
     id: uuid(),
@@ -53,7 +53,7 @@ router.post('/', (req, res) => {
 });
 
 // Update an existing location
-router.put('/:id', (req, res) => {
+router.put('/:id', validateUser('Dispatcher'), (req, res) => {
   const { params: { id }, body } = req;
   const { address } = body;
   if (address) {
@@ -63,7 +63,7 @@ router.put('/:id', (req, res) => {
 });
 
 // Delete an existing location
-router.delete('/:id', (req, res) => {
+router.delete('/:id', validateUser('Dispatcher'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Location, id, tableName);
 });

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -4,19 +4,19 @@ import { Condition } from 'dynamoose';
 import * as db from './common';
 import { Ride, RideType, Status, Type } from '../models/ride';
 import { Location, Tag } from '../models/location';
-import { formatAddress } from '../util';
+import { formatAddress, validateUser } from '../util';
 
 const router = express.Router();
 const tableName = 'Rides';
 
 // Get a ride by id in Rides table
-router.get('/:id', (req, res) => {
+router.get('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Ride, id, tableName);
 });
 
 // Get and query all rides in table
-router.get('/', (req, res) => {
+router.get('/', validateUser('User'), (req, res) => {
   const { query } = req;
   if (query === {}) {
     db.getAll(res, Ride, tableName);
@@ -45,7 +45,7 @@ router.get('/', (req, res) => {
 });
 
 // Put a ride in Rides table
-router.post('/', (req, res) => {
+router.post('/', validateUser('User'), (req, res) => {
   const {
     body: { rider, startTime, requestedEndTime, driver, startLocation, endLocation },
   } = req;
@@ -91,7 +91,7 @@ router.post('/', (req, res) => {
 });
 
 // Update an existing ride
-router.put('/:id', (req, res) => {
+router.put('/:id', validateUser('User'), (req, res) => {
   const { params: { id }, body } = req;
   if (body.type === Type.PAST) {
     db.getById(res, Ride, id, tableName, (ride) => {
@@ -115,7 +115,7 @@ router.put('/:id', (req, res) => {
 });
 
 // Delete an existing ride
-router.delete('/:id', (req, res) => {
+router.delete('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Ride, id, tableName);
 });

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import { v4 as uuid } from 'uuid';
 import { Condition } from 'dynamoose';
-import jwt from 'jsonwebtoken';
 import * as db from './common';
 import { Rider, RiderType } from '../models/rider';
 import { Location } from '../models/location';
@@ -17,7 +16,7 @@ router.get('/:id', validateUser('User'), (req, res) => {
 });
 
 // Get all riders
-router.get('/', validateUser('User'), (req, res) => {
+router.get('/', validateUser('Dispatcher'), (req, res) => {
   db.getAll(res, Rider, tableName);
 });
 
@@ -62,24 +61,14 @@ router.get('/:id/favorites', validateUser('User'), (req, res) => {
 });
 
 // Create a rider in Riders table
-router.post('/', validateUser('Rider'), (req, res) => {
+router.post('/', validateUser('Dispatcher'), (req, res) => {
   const { body } = req;
   const rider = new Rider({
     ...body,
     id: uuid(),
     favoriteLocations: [],
   });
-  db.create(res, rider, (data: RiderType) => {
-    const { locals: { user: { id } } } = res;
-    if (id) {
-      res.send(data);
-    } else {
-      res.send({
-        ...data,
-        jwt: jwt.sign({ id: data.id, userType: 'Rider' }, process.env.JWT_SECRET!),
-      });
-    }
-  });
+  db.create(res, rider);
 });
 
 // Update a rider in Riders table
@@ -105,7 +94,7 @@ router.post('/:id/favorites', validateUser('Rider'), (req, res) => {
 });
 
 // Delete an existing rider
-router.delete('/:id', validateUser('Rider'), (req, res) => {
+router.delete('/:id', validateUser('Dispatcher'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Rider, id, tableName);
 });

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { v4 as uuid } from 'uuid';
 import { Condition } from 'dynamoose';
+import jwt from 'jsonwebtoken';
 import * as db from './common';
 import { Rider, RiderType } from '../models/rider';
 import { Location } from '../models/location';
@@ -68,7 +69,17 @@ router.post('/', validateUser('Rider'), (req, res) => {
     id: uuid(),
     favoriteLocations: [],
   });
-  db.create(res, rider);
+  db.create(res, rider, (data: RiderType) => {
+    const { locals: { user: { id } } } = res;
+    if (id) {
+      res.send(data);
+    } else {
+      res.send({
+        ...data,
+        jwt: jwt.sign({ id: data.id, userType: 'Rider' }, process.env.JWT_SECRET!),
+      });
+    }
+  });
 });
 
 // Update a rider in Riders table

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -4,22 +4,24 @@ import { Condition } from 'dynamoose';
 import * as db from './common';
 import { Rider, RiderType } from '../models/rider';
 import { Location } from '../models/location';
-import { createKeys } from '../util';
+import { createKeys, validateUser } from '../util';
 
 const router = express.Router();
 const tableName = 'Riders';
 
 // Get a rider by id in Riders table
-router.get('/:id', (req, res) => {
+router.get('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Rider, id, tableName);
 });
 
 // Get all riders
-router.get('/', (req, res) => db.getAll(res, Rider, tableName));
+router.get('/', validateUser('User'), (req, res) => {
+  db.getAll(res, Rider, tableName);
+});
 
 // Get profile information for a rider
-router.get('/:id/profile', (req, res) => {
+router.get('/:id/profile', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Rider, id, tableName, (rider: RiderType) => {
     const {
@@ -32,7 +34,7 @@ router.get('/:id/profile', (req, res) => {
 });
 
 // Get accessibility information for a rider
-router.get('/:id/accessibility', async (req, res) => {
+router.get('/:id/accessibility', validateUser('User'), async (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Rider, id, tableName, (rider: RiderType) => {
     const { description, accessibility } = rider;
@@ -41,7 +43,7 @@ router.get('/:id/accessibility', async (req, res) => {
 });
 
 // Get organization information for a rider
-router.get('/:id/organization', async (req, res) => {
+router.get('/:id/organization', validateUser('User'), async (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Rider, id, tableName, (rider: RiderType) => {
     const { description, organization } = rider;
@@ -50,7 +52,7 @@ router.get('/:id/organization', async (req, res) => {
 });
 
 // Get all favorite locations for a rider
-router.get('/:id/favorites', (req, res) => {
+router.get('/:id/favorites', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Rider, id, tableName, ({ favoriteLocations }: RiderType) => {
     const keys = createKeys('id', favoriteLocations);
@@ -59,7 +61,7 @@ router.get('/:id/favorites', (req, res) => {
 });
 
 // Create a rider in Riders table
-router.post('/', (req, res) => {
+router.post('/', validateUser('Rider'), (req, res) => {
   const { body } = req;
   const rider = new Rider({
     ...body,
@@ -70,13 +72,13 @@ router.post('/', (req, res) => {
 });
 
 // Update a rider in Riders table
-router.put('/:id', (req, res) => {
+router.put('/:id', validateUser('Rider'), (req, res) => {
   const { params: { id }, body } = req;
   db.update(res, Rider, { id }, body, tableName);
 });
 
 // Add a location to favorites
-router.post('/:id/favorites', (req, res) => {
+router.post('/:id/favorites', validateUser('Rider'), (req, res) => {
   const { params: { id }, body: { id: locId } } = req;
   // check if location exists in table
   db.getById(res, Location, locId, 'Locations', () => {
@@ -92,7 +94,7 @@ router.post('/:id/favorites', (req, res) => {
 });
 
 // Delete an existing rider
-router.delete('/:id', (req, res) => {
+router.delete('/:id', validateUser('Rider'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Rider, id, tableName);
 });

--- a/server/router/vehicle.ts
+++ b/server/router/vehicle.ts
@@ -14,7 +14,7 @@ router.get('/:id', validateUser('User'), (req, res) => {
 });
 
 // Get all vehicles
-router.get('/', validateUser('User'), (req, res) => {
+router.get('/', validateUser('Dispatcher'), (req, res) => {
   db.getAll(res, Vehicle, tableName);
 });
 

--- a/server/router/vehicle.ts
+++ b/server/router/vehicle.ts
@@ -2,37 +2,40 @@ import express from 'express';
 import { v4 as uuid } from 'uuid';
 import * as db from './common';
 import { Vehicle } from '../models/vehicle';
+import { validateUser } from '../util';
 
 const router = express.Router();
 const tableName = 'Vehicles';
 
 // Get a vehicle by id
-router.get('/:id', (req, res) => {
+router.get('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Vehicle, id, tableName);
 });
 
 // Get all vehicles
-router.get('/', (req, res) => db.getAll(res, Vehicle, tableName));
+router.get('/', validateUser('User'), (req, res) => {
+  db.getAll(res, Vehicle, tableName);
+});
 
 // Create a new vehicle
-router.post('/', (req, res) => {
+router.post('/', validateUser('Dispatcher'), (req, res) => {
   const { body } = req;
   const vehicle = new Vehicle({
     ...body,
-    id: uuid()
+    id: uuid(),
   });
   db.create(res, vehicle);
 });
 
 // Update an existing vehicle
-router.put('/:id', (req, res) => {
+router.put('/:id', validateUser('Dispatcher'), (req, res) => {
   const { params: { id }, body } = req;
   db.update(res, Vehicle, { id }, body, tableName);
 });
 
 // Delete an existing vehicle
-router.delete('/:id', (req, res) => {
+router.delete('/:id', validateUser('Dispatcher'), (req, res) => {
   const { params: { id } } = req;
   db.deleteById(res, Vehicle, id, tableName);
 });

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -61,6 +61,8 @@ export function validateUser(authLevel: UserType) {
         } else {
           res.send({ err: 'User does not have sufficient permissions' });
         }
+      } else {
+        res.send({ err: 'Invalid token' });
       }
     });
   };

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -34,6 +34,8 @@ function validateToken(
           callback(payload as JWTPayload);
         }
       });
+    } else {
+      res.send({ err: 'Invalid token format' });
     }
   } else {
     res.send({ err: 'No token provided' });

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -40,13 +40,14 @@ function validateToken(
   }
 }
 
+const priority: { [type in UserType]: number } = {
+  User: 0,
+  Rider: 1,
+  Driver: 1,
+  Dispatcher: 2,
+};
+
 function isUserValid(userType: UserType, authLevel: UserType) {
-  const priority: { [type in UserType]: number } = {
-    User: 0,
-    Rider: 1,
-    Driver: 1,
-    Dispatcher: 2,
-  };
   return userType === authLevel || priority[authLevel] < priority[userType];
 }
 

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -18,7 +18,7 @@ export function formatAddress(address: string): string {
   return addressString.formattedAddress;
 }
 
-function validate(
+function validateToken(
   req: Request,
   res: Response,
   callback: (payload?: JWTPayload) => void,
@@ -52,7 +52,7 @@ function isUserValid(userType: UserType, authLevel: UserType) {
 
 export function validateUser(authLevel: UserType) {
   return (req: Request, res: Response, next: NextFunction) => {
-    validate(req, res, (payload) => {
+    validateToken(req, res, (payload) => {
       if (payload) {
         const { userType } = payload;
         if (isUserValid(userType, authLevel)) {

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -1,4 +1,7 @@
 import { parseAddress } from 'addresser';
+import { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { UserType, JWTPayload } from './types';
 
 export function createKeys(property: string, values: string[]) {
   return values.map((v) => ({ [property]: v }));
@@ -13,4 +16,52 @@ export function formatAddress(address: string): string {
     addressString = parseAddress(`${address}, Ithaca, NY 14850`) as any;
   }
   return addressString.formattedAddress;
+}
+
+function validate(
+  req: Request,
+  res: Response,
+  callback: (payload?: JWTPayload) => void,
+) {
+  const { authorization } = req.headers;
+  if (authorization) {
+    const [bearer, token] = authorization.split(' ');
+    if (bearer === 'Bearer') {
+      jwt.verify(token, process.env.JWT_SECRET!, (err, payload) => {
+        if (err) {
+          res.send({ err });
+        } else {
+          callback(payload as JWTPayload);
+        }
+      });
+    }
+  } else {
+    res.send({ err: 'No token provided' });
+  }
+}
+
+function isUserValid(userType: UserType, authLevel: UserType) {
+  const priority: { [type in UserType]: number } = {
+    User: 0,
+    Rider: 1,
+    Driver: 1,
+    Dispatcher: 2,
+  };
+  return userType === authLevel || priority[authLevel] < priority[userType];
+}
+
+export function validateUser(authLevel: UserType) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    validate(req, res, (payload) => {
+      if (payload) {
+        const { userType } = payload;
+        if (isUserValid(userType, authLevel)) {
+          res.locals.user = payload;
+          next();
+        } else {
+          res.send({ err: 'User does not have sufficient permissions' });
+        }
+      }
+    });
+  };
 }

--- a/server/util/types.ts
+++ b/server/util/types.ts
@@ -1,0 +1,7 @@
+export type UserType = 'User' | 'Rider' | 'Driver' | 'Dispatcher';
+
+export type JWTPayload = {
+  id: string;
+  userType: UserType;
+  iat: string;
+}


### PR DESCRIPTION
### Summary <!-- Required -->
This PR adds authorization to all endpoints, so now only authorized users with sufficient permissions can make requests to the API. 

When a user is authenticated by the `/auth` endpoint, the API will now return `{ jwt: string }` containing the JWT for the user to attach to all requests in the Authorization header, in the form `Authorization: Bearer <token>`. This JWT is of the form `{ id: string | null, userType: 'Rider' | 'Driver' | 'Dispatcher' }`, and is signed using a secret key in `.env`.

Endpoints can be restricted to any authenticated user or restricted to a certain `userType` and above by adding middleware of this form to any request: `router.get('/', validateUser('User' | 'Rider' | 'Driver' | 'Dispatcher'), (req, res) => ...)`.

### Test Plan <!-- Required -->
Authenticate an account through the `/auth` endpoint, and save the token. Make requests to other endpoints with and without the token, and with an edited token. Only the token given by the API should be valid.

### Notes <!-- Optional -->
The tokens do not expire, so if they get into the wrong hands there still can be a security issue. I felt that implementing refresh tokens might end up being a sizeable block to frontend development, so I chose to omit them for now. However they should be considered for the future.

### Breaking Changes  <!-- Optional -->
Generally the entire flow for making requests is changed, so frontend will need to implement a way to save tokens on client-side.
