### PR TITLE
Added prettier and format script

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,42 +1,47 @@
 {
-    "env": {
-        "browser": true
-    },
-    "extends": [
-        "airbnb-base",
-        "plugin:import/errors",
-        "plugin:import/warnings",
-        "plugin:import/typescript",
-        "react-app"
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": [
+    "airbnb-base",
+    "airbnb-typescript",
+    "airbnb/hooks",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "plugin:import/typescript",
+    "react-app",
+    "prettier",
+    "prettier/react",
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "plugins": ["promise", "@typescript-eslint", "react", "react-hooks"],
+  "rules": {
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never"
+      }
     ],
-    "globals": {
-        "Atomics": "readonly",
-        "SharedArrayBuffer": "readonly"
-    },
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "promise",
-        "@typescript-eslint",
-        "react-hooks"
-    ],
-    "rules": {
-        "import/extensions": [
-            "error",
-            "ignorePackages",
-            {
-                "js": "never",
-                "jsx": "never",
-                "ts": "never",
-                "tsx": "never"
-            }
-        ],
-        "linebreak-style": "off",
-        "object-curly-newline": "off",
-        "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "warn"
-    }
+    "linebreak-style": "off",
+    "object-curly-newline": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "prettier/prettier": ["error"]
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "jsxBracketSameLine": true,
+  "arrowParens": "always"
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2564,7 +2564,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2945,8 +2944,7 @@
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -3582,16 +3580,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -4652,6 +4640,18 @@
         "is-directory": "^0.3.1",
         "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
       }
     },
     "create-ecdh": {
@@ -6720,8 +6720,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -7410,8 +7409,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "growly": {
       "version": "1.3.0",
@@ -7452,7 +7450,6 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -7959,9 +7956,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -9064,7 +9061,10 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1"
+          }
         }
       }
     },
@@ -10524,6 +10524,18 @@
         "parse-json": "^4.0.0",
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
       }
     },
     "loader-fs-cache": {
@@ -10903,6 +10915,11 @@
             "pinkie-promise": "^2.0.0"
           }
         },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
         "read-pkg": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -11046,14 +11063,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -11927,17 +11942,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
-    "os-locale": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -12103,8 +12107,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse5": {
@@ -15440,7 +15443,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -15449,14 +15451,12 @@
     "spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -15465,8 +15465,7 @@
     "spdx-license-ids": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
-      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
-      "dev": true
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw=="
     },
     "spdy": {
       "version": "4.0.2",
@@ -16634,7 +16633,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -16886,7 +16884,10 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -17183,7 +17184,10 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,20 +70,22 @@
             "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
         },
         "@babel/runtime": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-            "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+            "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+            "dev": true,
             "requires": {
-                "regenerator-runtime": "^0.13.2"
+                "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/runtime-corejs3": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
-            "integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
+            "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+            "dev": true,
             "requires": {
                 "core-js-pure": "^3.0.0",
-                "regenerator-runtime": "^0.13.2"
+                "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/template": {
@@ -129,6 +131,32 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
         "@types/eslint-visitor-keys": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -144,9 +172,15 @@
             }
         },
         "@types/json-schema": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-            "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+            "dev": true
+        },
+        "@types/json5": {
+            "version": "0.0.29",
+            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+            "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
         },
         "@types/prop-types": {
@@ -169,45 +203,72 @@
             "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.0.tgz",
-            "integrity": "sha512-u7IcQ9qwsB6U806LupZmINRnQjC+RJyv36sV/ugaFWMHTbFm/hlLTRx3gGYJgHisxcGSTnf+I/fPDieRMhPSQQ==",
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
+            "integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "2.19.0",
-                "eslint-utils": "^1.4.3",
+                "@typescript-eslint/experimental-utils": "2.34.0",
                 "functional-red-black-tree": "^1.0.1",
                 "regexpp": "^3.0.0",
                 "tsutils": "^3.17.1"
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz",
-            "integrity": "sha512-zwpg6zEOPbhB3+GaQfufzlMUOO6GXCNZq6skk+b2ZkZAIoBhVoanWK255BS1g5x9bMwHpLhX0Rpn5Fc3NdCZdg==",
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+            "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/typescript-estree": "2.19.0",
-                "eslint-scope": "^5.0.0"
+                "@typescript-eslint/typescript-estree": "2.34.0",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "eslint-utils": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.19.0.tgz",
-            "integrity": "sha512-s0jZoxAWjHnuidbbN7aA+BFVXn4TCcxEVGPV8lWMxZglSs3NRnFFAlL+aIENNmzB2/1jUJuySi6GiM6uACPmpg==",
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
+            "integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
             "dev": true,
             "requires": {
                 "@types/eslint-visitor-keys": "^1.0.0",
-                "@typescript-eslint/experimental-utils": "2.19.0",
-                "@typescript-eslint/typescript-estree": "2.19.0",
+                "@typescript-eslint/experimental-utils": "2.34.0",
+                "@typescript-eslint/typescript-estree": "2.34.0",
                 "eslint-visitor-keys": "^1.1.0"
             }
         },
+        "@typescript-eslint/scope-manager": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.9.1.tgz",
+            "integrity": "sha512-sa4L9yUfD/1sg9Kl8OxPxvpUcqxKXRjBeZxBuZSSV1v13hjfEJkn84n0An2hN8oLQ1PmEl2uA6FkI07idXeFgQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.9.1",
+                "@typescript-eslint/visitor-keys": "4.9.1"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz",
+            "integrity": "sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA==",
+            "dev": true
+        },
         "@typescript-eslint/typescript-estree": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.0.tgz",
-            "integrity": "sha512-n6/Xa37k0jQdwpUszffi19AlNbVCR0sdvCs3DmSKMD7wBttKY31lhD2fug5kMD91B2qW4mQldaTEc1PEzvGu8w==",
+            "version": "2.34.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+            "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
             "dev": true,
             "requires": {
                 "debug": "^4.1.1",
@@ -215,8 +276,52 @@
                 "glob": "^7.1.6",
                 "is-glob": "^4.0.1",
                 "lodash": "^4.17.15",
-                "semver": "^6.3.0",
+                "semver": "^7.3.2",
                 "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.1.tgz",
+            "integrity": "sha512-9gspzc6UqLQHd7lXQS7oWs+hrYggspv/rk6zzEMhCbYwPE/sF7oxo7GAjkS35Tdlt7wguIG+ViWCPtVZHz/ybQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.9.1",
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+                    "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+                    "dev": true
+                }
             }
         },
         "abort-controller": {
@@ -302,12 +407,13 @@
             }
         },
         "aria-query": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-            "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+            "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+            "dev": true,
             "requires": {
-                "ast-types-flow": "0.0.7",
-                "commander": "^2.11.0"
+                "@babel/runtime": "^7.10.2",
+                "@babel/runtime-corejs3": "^7.10.2"
             }
         },
         "array-flatten": {
@@ -316,22 +422,210 @@
             "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "array-includes": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
-            "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.2.tgz",
+            "integrity": "sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==",
+            "dev": true,
             "requires": {
+                "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0",
+                "es-abstract": "^1.18.0-next.1",
+                "get-intrinsic": "^1.0.1",
                 "is-string": "^1.0.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
+        },
         "array.prototype.flat": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
-            "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+            "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+            "dev": true,
             "requires": {
+                "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1"
+                "es-abstract": "^1.18.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
+            }
+        },
+        "array.prototype.flatmap": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+            "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.1",
+                "function-bind": "^1.1.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "arrify": {
@@ -342,21 +636,25 @@
         "ast-types-flow": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-            "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+            "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+            "dev": true
         },
         "astral-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
         },
+        "axe-core": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
+            "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
+            "dev": true
+        },
         "axobject-query": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
-            "integrity": "sha512-lF98xa/yvy6j3fBHAgQXIYl+J4eZadOSqsPojemUqClzNbBV38wWGpUbQbVEyf4eUF5yF7eHmGgGA2JiHyjeqw==",
-            "requires": {
-                "@babel/runtime": "^7.7.4",
-                "@babel/runtime-corejs3": "^7.7.4"
-            }
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+            "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+            "dev": true
         },
         "babel-eslint": {
             "version": "10.1.0",
@@ -427,6 +725,15 @@
                 "concat-map": "0.0.1"
             }
         },
+        "braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.0.1"
+            }
+        },
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -436,6 +743,16 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
             "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        },
+        "call-bind": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+            "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.0"
+            }
         },
         "callsites": {
             "version": "3.1.0",
@@ -483,11 +800,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
-        "commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -501,7 +813,8 @@
         "contains-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
         },
         "content-disposition": {
             "version": "0.5.3",
@@ -534,9 +847,10 @@
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
         "core-js-pure": {
-            "version": "3.6.4",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-            "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.1.tgz",
+            "integrity": "sha512-Se+LaxqXlVXGvmexKGPvnUIYC1jwXu1H6Pkyb3uBM5d8/NELMYCHs/4/roD7721NxrTLyv7e5nXd5/QLBO+10g==",
+            "dev": true
         },
         "cross-spawn": {
             "version": "6.0.5",
@@ -565,7 +879,8 @@
         "damerau-levenshtein": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
-            "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug=="
+            "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
+            "dev": true
         },
         "debug": {
             "version": "4.1.1",
@@ -597,6 +912,23 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                }
+            }
         },
         "doctrine": {
             "version": "3.0.0",
@@ -633,6 +965,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -726,6 +1059,101 @@
                 }
             }
         },
+        "eslint-config-airbnb": {
+            "version": "18.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
+            "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+            "dev": true,
+            "requires": {
+                "eslint-config-airbnb-base": "^14.2.1",
+                "object.assign": "^4.1.2",
+                "object.entries": "^1.1.2"
+            },
+            "dependencies": {
+                "confusing-browser-globals": {
+                    "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+                    "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+                    "dev": true
+                },
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "eslint-config-airbnb-base": {
+                    "version": "14.2.1",
+                    "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+                    "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+                    "dev": true,
+                    "requires": {
+                        "confusing-browser-globals": "^1.0.10",
+                        "object.assign": "^4.1.2",
+                        "object.entries": "^1.1.2"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                },
+                "object.entries": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+                    "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.18.0-next.1",
+                        "has": "^1.0.3"
+                    }
+                }
+            }
+        },
         "eslint-config-airbnb-base": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
@@ -734,6 +1162,26 @@
                 "confusing-browser-globals": "^1.0.7",
                 "object.assign": "^4.1.0",
                 "object.entries": "^1.1.0"
+            }
+        },
+        "eslint-config-airbnb-typescript": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-6.3.2.tgz",
+            "integrity": "sha512-JdwaDl+0vX223MSKRyY+K8tQzrTcVDc3xCd3BtpQ4wsvu74Nbvvz7Ikuo/9ddFGZ2bNrYkfmXsPPrTdBJIxYug==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/parser": "^2.3.0",
+                "eslint-config-airbnb": "^18.0.1",
+                "eslint-config-airbnb-base": "^14.0.0"
+            }
+        },
+        "eslint-config-prettier": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+            "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^6.0.0"
             }
         },
         "eslint-config-react-app": {
@@ -745,9 +1193,10 @@
             }
         },
         "eslint-import-resolver-node": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
-            "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+            "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+            "dev": true,
             "requires": {
                 "debug": "^2.6.9",
                 "resolve": "^1.13.1"
@@ -757,6 +1206,7 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -764,14 +1214,16 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
         "eslint-module-utils": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
-            "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+            "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+            "dev": true,
             "requires": {
                 "debug": "^2.6.9",
                 "pkg-dir": "^2.0.0"
@@ -781,6 +1233,7 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -788,7 +1241,8 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -801,28 +1255,31 @@
             }
         },
         "eslint-plugin-import": {
-            "version": "2.20.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
-            "integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
+            "version": "2.22.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+            "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+            "dev": true,
             "requires": {
-                "array-includes": "^3.0.3",
-                "array.prototype.flat": "^1.2.1",
+                "array-includes": "^3.1.1",
+                "array.prototype.flat": "^1.2.3",
                 "contains-path": "^0.1.0",
                 "debug": "^2.6.9",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "^0.3.2",
-                "eslint-module-utils": "^2.4.1",
+                "eslint-import-resolver-node": "^0.3.4",
+                "eslint-module-utils": "^2.6.0",
                 "has": "^1.0.3",
                 "minimatch": "^3.0.4",
-                "object.values": "^1.1.0",
+                "object.values": "^1.1.1",
                 "read-pkg-up": "^2.0.0",
-                "resolve": "^1.12.0"
+                "resolve": "^1.17.0",
+                "tsconfig-paths": "^3.9.0"
             },
             "dependencies": {
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -831,6 +1288,7 @@
                     "version": "1.5.0",
                     "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
                     "requires": {
                         "esutils": "^2.0.2",
                         "isarray": "^1.0.0"
@@ -839,31 +1297,129 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.19.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+                    "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+                    "dev": true,
+                    "requires": {
+                        "is-core-module": "^2.1.0",
+                        "path-parse": "^1.0.6"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-jest": {
+            "version": "24.1.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",
+            "integrity": "sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/experimental-utils": "^4.0.1"
+            },
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": {
+                    "version": "4.9.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.9.1.tgz",
+                    "integrity": "sha512-c3k/xJqk0exLFs+cWSJxIjqLYwdHCuLWhnpnikmPQD2+NGAx9KjLYlBDcSI81EArh9FDYSL6dslAUSwILeWOxg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.3",
+                        "@typescript-eslint/scope-manager": "4.9.1",
+                        "@typescript-eslint/types": "4.9.1",
+                        "@typescript-eslint/typescript-estree": "4.9.1",
+                        "eslint-scope": "^5.0.0",
+                        "eslint-utils": "^2.0.0"
+                    }
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "4.9.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.1.tgz",
+                    "integrity": "sha512-bzP8vqwX6Vgmvs81bPtCkLtM/Skh36NE6unu6tsDeU/ZFoYthlTXbBmpIrvosgiDKlWTfb2ZpPELHH89aQjeQw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.9.1",
+                        "@typescript-eslint/visitor-keys": "4.9.1",
+                        "debug": "^4.1.1",
+                        "globby": "^11.0.1",
+                        "is-glob": "^4.0.1",
+                        "lodash": "^4.17.15",
+                        "semver": "^7.3.2",
+                        "tsutils": "^3.17.1"
+                    }
+                },
+                "eslint-utils": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
                 }
             }
         },
         "eslint-plugin-jsx-a11y": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
-            "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
+            "integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
+            "dev": true,
             "requires": {
-                "@babel/runtime": "^7.4.5",
-                "aria-query": "^3.0.0",
-                "array-includes": "^3.0.3",
+                "@babel/runtime": "^7.11.2",
+                "aria-query": "^4.2.2",
+                "array-includes": "^3.1.1",
                 "ast-types-flow": "^0.0.7",
-                "axobject-query": "^2.0.2",
-                "damerau-levenshtein": "^1.0.4",
-                "emoji-regex": "^7.0.2",
+                "axe-core": "^4.0.2",
+                "axobject-query": "^2.2.0",
+                "damerau-levenshtein": "^1.0.6",
+                "emoji-regex": "^9.0.0",
                 "has": "^1.0.3",
-                "jsx-ast-utils": "^2.2.1"
+                "jsx-ast-utils": "^3.1.0",
+                "language-tags": "^1.0.5"
             },
             "dependencies": {
                 "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+                    "version": "9.2.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
+                    "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
+                    "dev": true
                 }
+            }
+        },
+        "eslint-plugin-prettier": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.2.0.tgz",
+            "integrity": "sha512-kOUSJnFjAUFKwVxuzy6sA5yyMx6+o9ino4gCdShzBNx4eyFRudWRYKCFolKjoM40PEiuU6Cn7wBLfq3WsGg7qg==",
+            "dev": true,
+            "requires": {
+                "prettier-linter-helpers": "^1.0.0"
             }
         },
         "eslint-plugin-promise": {
@@ -872,19 +1428,21 @@
             "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw=="
         },
         "eslint-plugin-react": {
-            "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.3.tgz",
-            "integrity": "sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==",
+            "version": "7.21.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+            "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
+            "dev": true,
             "requires": {
                 "array-includes": "^3.1.1",
+                "array.prototype.flatmap": "^1.2.3",
                 "doctrine": "^2.1.0",
                 "has": "^1.0.3",
-                "jsx-ast-utils": "^2.2.3",
-                "object.entries": "^1.1.1",
+                "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+                "object.entries": "^1.1.2",
                 "object.fromentries": "^2.0.2",
                 "object.values": "^1.1.1",
                 "prop-types": "^15.7.2",
-                "resolve": "^1.14.2",
+                "resolve": "^1.18.1",
                 "string.prototype.matchall": "^4.0.2"
             },
             "dependencies": {
@@ -892,8 +1450,84 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
                     "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+                    "dev": true,
                     "requires": {
                         "esutils": "^2.0.2"
+                    }
+                },
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                },
+                "object.entries": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+                    "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.18.0-next.1",
+                        "has": "^1.0.3"
+                    }
+                },
+                "resolve": {
+                    "version": "1.19.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+                    "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+                    "dev": true,
+                    "requires": {
+                        "is-core-module": "^2.1.0",
+                        "path-parse": "^1.0.6"
                     }
                 }
             }
@@ -1061,6 +1695,26 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
+        "fast-diff": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+            "dev": true
+        },
+        "fast-glob": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+            "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1076,6 +1730,15 @@
             "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz",
             "integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ=="
         },
+        "fastq": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+            "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
+        },
         "figures": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -1090,6 +1753,15 @@
             "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
             "requires": {
                 "flat-cache": "^2.0.1"
+            }
+        },
+        "fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
             }
         },
         "finalhandler": {
@@ -1125,6 +1797,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
             "requires": {
                 "locate-path": "^2.0.0"
             }
@@ -1204,6 +1877,23 @@
                 }
             }
         },
+        "get-intrinsic": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+            "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "get-stdin": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+            "dev": true
+        },
         "glob": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1233,6 +1923,28 @@
                 "type-fest": "^0.8.1"
             }
         },
+        "globby": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+            "dev": true,
+            "requires": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
+                }
+            }
+        },
         "google-auth-library": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.0.tgz",
@@ -1250,33 +1962,34 @@
             }
         },
         "google-p12-pem": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
-            "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+            "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
             "requires": {
-                "node-forge": "^0.9.0"
+                "node-forge": "^0.10.0"
             }
         },
         "graceful-fs": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
         },
         "gtoken": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.0.tgz",
-            "integrity": "sha512-+TM/Mn9fm2LsAA3bZVSlCG20b0KfDdF6IC/mV/rRWuIUAwvXd2aMCGFNf1ont1qFzJh0tznnfEyY8YLQ1awqdw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
+            "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
             "requires": {
-                "gaxios": "^2.1.0",
-                "google-p12-pem": "^2.0.0",
+                "gaxios": "^4.0.0",
+                "google-p12-pem": "^3.0.3",
                 "jws": "^4.0.0",
                 "mime": "^2.2.0"
             },
             "dependencies": {
                 "gaxios": {
-                    "version": "2.3.4",
-                    "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.4.tgz",
-                    "integrity": "sha512-US8UMj8C5pRnao3Zykc4AAVr+cffoNKRTg9Rsf2GiuZCW69vgJj38VK2PzlPuQU73FZ/nTk9/Av6/JGcE1N9vA==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+                    "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
                     "requires": {
                         "abort-controller": "^3.0.0",
                         "extend": "^3.0.2",
@@ -1306,9 +2019,10 @@
             "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "hosted-git-info": {
-            "version": "2.8.5",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-            "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+            "dev": true
         },
         "http-errors": {
             "version": "1.7.2",
@@ -1456,6 +2170,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
             "integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
+            "dev": true,
             "requires": {
                 "es-abstract": "^1.17.0-next.1",
                 "has": "^1.0.3",
@@ -1470,12 +2185,22 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
         },
         "is-callable": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
             "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+        },
+        "is-core-module": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
         },
         "is-date-object": {
             "version": "1.0.2",
@@ -1500,6 +2225,18 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+            "dev": true
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
+        },
         "is-regex": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -1516,7 +2253,8 @@
         "is-string": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+            "dev": true
         },
         "is-symbol": {
             "version": "1.0.3",
@@ -1529,7 +2267,8 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -1573,13 +2312,37 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
         },
-        "jsx-ast-utils": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
-            "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+        "json5": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+            "dev": true,
             "requires": {
-                "array-includes": "^3.0.3",
-                "object.assign": "^4.1.0"
+                "minimist": "^1.2.0"
+            }
+        },
+        "jsx-ast-utils": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
+            "integrity": "sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==",
+            "dev": true,
+            "requires": {
+                "array-includes": "^3.1.1",
+                "object.assign": "^4.1.1"
+            },
+            "dependencies": {
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "jwa": {
@@ -1601,6 +2364,21 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "language-subtag-registry": {
+            "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
+            "integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
+            "dev": true
+        },
+        "language-tags": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+            "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+            "dev": true,
+            "requires": {
+                "language-subtag-registry": "~0.3.2"
+            }
+        },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1614,6 +2392,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -1625,6 +2404,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
             "requires": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -1661,15 +2441,31 @@
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
         },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
+        },
         "methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
         },
+        "micromatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+            }
+        },
         "mime": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+            "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "mime-db": {
             "version": "1.43.0",
@@ -1741,14 +2537,15 @@
             "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "node-forge": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-            "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         },
         "normalize-package-data": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
@@ -1759,7 +2556,8 @@
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
                 }
             }
         },
@@ -1801,25 +2599,137 @@
             }
         },
         "object.fromentries": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
-            "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.3.tgz",
+            "integrity": "sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==",
+            "dev": true,
             "requires": {
+                "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1",
-                "function-bind": "^1.1.1",
+                "es-abstract": "^1.18.0-next.1",
                 "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "object.values": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
-            "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.2.tgz",
+            "integrity": "sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==",
+            "dev": true,
             "requires": {
+                "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1",
-                "function-bind": "^1.1.1",
+                "es-abstract": "^1.18.0-next.1",
                 "has": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "on-finished": {
@@ -1868,6 +2778,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
             "requires": {
                 "p-try": "^1.0.0"
             }
@@ -1876,6 +2787,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
             "requires": {
                 "p-limit": "^1.1.0"
             }
@@ -1883,7 +2795,8 @@
         "p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
         },
         "parent-module": {
             "version": "1.0.1",
@@ -1897,6 +2810,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -1909,7 +2823,8 @@
         "path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -1935,19 +2850,28 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true,
             "requires": {
                 "pify": "^2.0.0"
             }
         },
+        "picomatch": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "dev": true
+        },
         "pify": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
         },
         "pkg-dir": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
             "requires": {
                 "find-up": "^2.1.0"
             }
@@ -1956,6 +2880,21 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+        },
+        "prettier": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+            "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+            "dev": true
+        },
+        "prettier-linter-helpers": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+            "dev": true,
+            "requires": {
+                "fast-diff": "^1.1.2"
+            }
         },
         "progress": {
             "version": "2.0.3",
@@ -2025,6 +2964,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true,
             "requires": {
                 "load-json-file": "^2.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -2035,29 +2975,32 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
                 "read-pkg": "^2.0.0"
             }
         },
         "regenerator-runtime": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-            "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+            "version": "0.13.7",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+            "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+            "dev": true
         },
         "regexp.prototype.flags": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
             "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+            "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
             }
         },
         "regexpp": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-            "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
             "dev": true
         },
         "resolve": {
@@ -2082,6 +3025,12 @@
                 "signal-exit": "^3.0.2"
             }
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rimraf": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -2094,6 +3043,12 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
             "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+        },
+        "run-parallel": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+            "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+            "dev": true
         },
         "rxjs": {
             "version": "6.6.3",
@@ -2195,18 +3150,80 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "side-channel": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
-            "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.3.tgz",
+            "integrity": "sha512-A6+ByhlLkksFoUepsGxfj5x1gTSrs+OydsRptUxeNCabQpCFUvcwIczgOigI8vhY/OJCnPnyE9rGiwgvr9cS1g==",
+            "dev": true,
             "requires": {
-                "es-abstract": "^1.17.0-next.1",
-                "object-inspect": "^1.7.0"
+                "es-abstract": "^1.18.0-next.0",
+                "object-inspect": "^1.8.0"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+        },
+        "slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -2231,32 +3248,36 @@
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "spdx-correct": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "dev": true
         },
         "spdx-expression-parse": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+            "dev": true
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -2289,16 +3310,83 @@
             }
         },
         "string.prototype.matchall": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
-            "integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
+            "integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
+            "dev": true,
             "requires": {
+                "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0",
+                "es-abstract": "^1.18.0-next.1",
                 "has-symbols": "^1.0.1",
                 "internal-slot": "^1.0.2",
                 "regexp.prototype.flags": "^1.3.0",
-                "side-channel": "^1.0.2"
+                "side-channel": "^1.0.3"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+                    "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+            "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
             }
         },
         "string.prototype.trimleft": {
@@ -2319,6 +3407,16 @@
                 "function-bind": "^1.1.1"
             }
         },
+        "string.prototype.trimstart": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+            "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+            }
+        },
         "strip-ansi": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -2337,7 +3435,8 @@
         "strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
         },
         "strip-json-comments": {
             "version": "3.1.1",
@@ -2408,10 +3507,31 @@
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
         },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
         "toidentifier": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+        },
+        "tsconfig-paths": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+            "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+            "dev": true,
+            "requires": {
+                "@types/json5": "^0.0.29",
+                "json5": "^1.0.1",
+                "minimist": "^1.2.0",
+                "strip-bom": "^3.0.0"
+            }
         },
         "tslib": {
             "version": "1.10.0",
@@ -2481,6 +3601,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,45 +1,51 @@
 {
-    "name": "carriage-web",
-    "version": "1.0.0",
-    "description": "",
-    "main": "index.js",
-    "dependencies": {
-        "@types/jquery": "^3.3.33",
-        "babel-eslint": "^10.1.0",
-        "eslint": "^6.8.0",
-        "eslint-config-airbnb-base": "^14.0.0",
-        "eslint-config-react-app": "^5.2.0",
-        "eslint-plugin-flowtype": "^3.13.0",
-        "eslint-plugin-import": "^2.20.1",
-        "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-promise": "^4.2.1",
-        "eslint-plugin-react": "^7.18.3",
-        "express": "^4.17.1",
-        "google-auth-library": "^6.0.0",
-        "react-google-login": "^5.1.3",
-        "typescript": "^4.0.3"
-    },
-    "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^2.18.0",
-        "@typescript-eslint/parser": "^2.18.0",
-        "eslint-plugin-react-hooks": "^1.7.0"
-    },
-    "scripts": {
-        "heroku-postbuild": "cd server && npm run tsc",
-        "install:frontend": "cd frontend && npm install && cd ..",
-        "install:server": "cd server && npm install && cd ..",
-        "postinstall": "npm run install:frontend && npm run install:server",
-        "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/cornell-dti/carriage-web.git"
-    },
-    "author": "",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/cornell-dti/carriage-web/issues"
-    },
-    "homepage": "https://github.com/cornell-dti/carriage-web#readme"
+  "name": "carriage-web",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "@types/jquery": "^3.3.33",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-react-app": "^5.2.0",
+    "eslint-plugin-flowtype": "^3.13.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "express": "^4.17.1",
+    "google-auth-library": "^6.0.0",
+    "react-google-login": "^5.1.3",
+    "typescript": "^4.0.3"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.34.0",
+    "@typescript-eslint/parser": "^2.34.0",
+    "eslint-config-airbnb-typescript": "^6.3.2",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.1.3",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^3.2.0",
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "prettier": "^2.2.1"
+  },
+  "scripts": {
+    "heroku-postbuild": "cd server && npm run tsc",
+    "install:frontend": "cd frontend && npm install && cd ..",
+    "install:server": "cd server && npm install && cd ..",
+    "postinstall": "npm run install:frontend && npm run install:server",
+    "format": "prettier --write frontend/src/{,**/}*.ts{,x} server/{,**/}*.ts",
+    "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cornell-dti/carriage-web.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/cornell-dti/carriage-web/issues"
+  },
+  "homepage": "https://github.com/cornell-dti/carriage-web#readme"
 }

--- a/server/models/dispatcher.ts
+++ b/server/models/dispatcher.ts
@@ -8,12 +8,12 @@ export enum AccessLevel {
 }
 
 export type DispatcherType = {
-  id: string,
-  firstName: string,
-  lastName: string,
-  phoneNumber: string,
-  email: string,
-  accessLevel: AccessLevel
+  id: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string;
+  email: string;
+  accessLevel: AccessLevel;
 };
 
 const schema = new dynamoose.Schema({
@@ -28,4 +28,6 @@ const schema = new dynamoose.Schema({
   },
 });
 
-export const Dispatcher = dynamoose.model('Dispatchers', schema, { create: false });
+export const Dispatcher = dynamoose.model('Dispatchers', schema, {
+  create: false,
+});

--- a/server/models/driver.ts
+++ b/server/models/driver.ts
@@ -2,26 +2,26 @@ import dynamoose from 'dynamoose';
 import { Vehicle, VehicleType } from './vehicle';
 
 type Availability = {
-  startTime: string,
-  endTime: string,
-}
+  startTime: string;
+  endTime: string;
+};
 
 type AvailabilityType = {
-  Mon?: Availability,
-  Tue?: Availability,
-  Wed?: Availability,
-  Thu?: Availability,
-  Fri?: Availability,
-}
+  Mon?: Availability;
+  Tue?: Availability;
+  Wed?: Availability;
+  Thu?: Availability;
+  Fri?: Availability;
+};
 
 export type DriverType = {
-  id: string,
-  firstName: string,
-  lastName: string,
-  availability: AvailabilityType,
-  vehicle: VehicleType,
-  phoneNumber: string,
-  email: string,
+  id: string;
+  firstName: string;
+  lastName: string;
+  availability: AvailabilityType;
+  vehicle: VehicleType;
+  phoneNumber: string;
+  email: string;
 };
 
 const availability = {

--- a/server/models/location.ts
+++ b/server/models/location.ts
@@ -7,7 +7,7 @@ export enum Tag {
   CTOWN = 'ctown', // college town
   DTOWN = 'dtown', // downtown
   INACTIVE = 'inactive',
-  CUSTOM = 'custom'
+  CUSTOM = 'custom',
 }
 
 export type LocationType = {

--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -19,22 +19,22 @@ export enum Status {
 }
 
 export type RideType = {
-  id: string,
-  type: Type,
-  status: Status,
-  late: boolean,
-  startLocation: LocationType,
-  endLocation: LocationType,
-  startTime: string,
-  requestedEndTime: string,
-  endTime: string,
-  rider: RiderType,
-  driver?: DriverType,
-  recurring?: boolean,
-  recurringDays?: number[],
-  endDate?: string
-  deleted?: boolean,
-  edits?: string[],
+  id: string;
+  type: Type;
+  status: Status;
+  late: boolean;
+  startLocation: LocationType;
+  endLocation: LocationType;
+  startTime: string;
+  requestedEndTime: string;
+  endTime: string;
+  rider: RiderType;
+  driver?: DriverType;
+  recurring?: boolean;
+  recurringDays?: number[];
+  endDate?: string;
+  deleted?: boolean;
+  edits?: string[];
 };
 
 const schema = new dynamoose.Schema({

--- a/server/models/rider.ts
+++ b/server/models/rider.ts
@@ -8,22 +8,22 @@ export enum Accessibility {
 
 export enum Organization {
   REDRUNNER = 'RedRunner',
-  CULIFT = 'CULift'
+  CULIFT = 'CULift',
 }
 
 export type RiderType = {
-  id: string
-  firstName: string
-  lastName: string
-  phoneNumber: string
-  email: string
-  accessibility: Accessibility[]
-  organization: Organization
-  description: string
-  joinDate: string
-  pronouns: string
-  address: string
-  favoriteLocations: string[]
+  id: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber: string;
+  email: string;
+  accessibility: Accessibility[];
+  organization: Organization;
+  description: string;
+  joinDate: string;
+  pronouns: string;
+  address: string;
+  favoriteLocations: string[];
 };
 
 const schema = new dynamoose.Schema({

--- a/server/models/vehicle.ts
+++ b/server/models/vehicle.ts
@@ -1,10 +1,10 @@
 import dynamoose from 'dynamoose';
 
 export type VehicleType = {
-  id: string,
-  name: string,
-  capacity: number,
-  wheelchairAccessible: boolean,
+  id: string;
+  name: string;
+  capacity: number;
+  wheelchairAccessible: boolean;
 };
 
 const schema = new dynamoose.Schema({

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -933,9 +933,9 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "ipaddr.js": {
             "version": "1.9.0",

--- a/server/router/common.ts
+++ b/server/router/common.ts
@@ -11,7 +11,7 @@ export function getById(
   model: ModelType,
   id: string | ObjectType,
   table: string,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
   model.get(id, (err, data) => {
     if (err) {
@@ -31,7 +31,7 @@ export function batchGet(
   model: ModelType,
   keys: ObjectType[],
   table: string,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
   if (!keys.length) {
     res.send({ data: [] });
@@ -53,7 +53,7 @@ export function getAll(
   res: Response,
   model: ModelType,
   table: string,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
   model.scan().exec((err, data) => {
     if (err) {
@@ -71,7 +71,7 @@ export function getAll(
 export function create(
   res: Response,
   doc: Document,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
   doc.save((err, data) => {
     if (err) {
@@ -90,7 +90,7 @@ export function update(
   key: ObjectType,
   operation: ObjectType,
   table: string,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
   model.update(key, operation, (err, data) => {
     if (err) {
@@ -112,19 +112,24 @@ export function conditionalUpdate(
   operation: ObjectType,
   condition: Condition,
   table: string,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
-  model.update(key, operation, { condition, return: 'document' }, (err, data) => {
-    if (err) {
-      res.send({ err });
-    } else if (!data) {
-      res.send({ err: { message: `id not found in ${table}` } });
-    } else if (callback) {
-      callback(data);
-    } else {
-      res.send(data);
+  model.update(
+    key,
+    operation,
+    { condition, return: 'document' },
+    (err, data) => {
+      if (err) {
+        res.send({ err });
+      } else if (!data) {
+        res.send({ err: { message: `id not found in ${table}` } });
+      } else if (callback) {
+        callback(data);
+      } else {
+        res.send(data);
+      }
     }
-  });
+  );
 }
 
 export function deleteById(
@@ -132,7 +137,7 @@ export function deleteById(
   model: ModelType,
   id: string | ObjectType,
   table: string,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
   model.get(id, (err, data) => {
     if (err) {
@@ -152,7 +157,7 @@ export function query(
   model: ModelType,
   condition: Condition,
   index: string,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
   model
     .query(condition)
@@ -172,17 +177,15 @@ export function scan(
   res: Response,
   model: ModelType,
   condition: Condition,
-  callback?: (value: any) => void,
+  callback?: (value: any) => void
 ) {
-  model
-    .scan(condition)
-    .exec((err, data) => {
-      if (err) {
-        res.send({ err });
-      } else if (callback) {
-        callback(data);
-      } else {
-        res.send({ data });
-      }
-    });
+  model.scan(condition).exec((err, data) => {
+    if (err) {
+      res.send({ err });
+    } else if (callback) {
+      callback(data);
+    } else {
+      res.send({ data });
+    }
+  });
 }

--- a/server/router/dispatcher.ts
+++ b/server/router/dispatcher.ts
@@ -11,14 +11,16 @@ router.post('/', (req, res) => {
   const { body } = req;
   const dispatcher = new Dispatcher({
     ...body,
-    id: uuid()
+    id: uuid(),
   });
   db.create(res, dispatcher);
 });
 
 // Remove Dispatcher
 router.delete('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.deleteById(res, Dispatcher, id, tableName);
 });
 

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -8,7 +8,9 @@ const tableName = 'Drivers';
 
 // Get a driver by id in Drivers table
 router.get('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Driver, id, tableName);
 });
 
@@ -17,13 +19,25 @@ router.get('/', (req, res) => db.getAll(res, Driver, tableName));
 
 // Get profile information for a driver
 router.get('/:id/profile', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Driver, id, tableName, (driver: DriverType) => {
     const {
-      email, firstName, lastName, phoneNumber, availability, vehicle,
+      email,
+      firstName,
+      lastName,
+      phoneNumber,
+      availability,
+      vehicle,
     } = driver;
     res.send({
-      email, firstName, lastName, phoneNumber, availability, vehicle,
+      email,
+      firstName,
+      lastName,
+      phoneNumber,
+      availability,
+      vehicle,
     });
   });
 });
@@ -33,20 +47,25 @@ router.post('/', (req, res) => {
   const { body } = req;
   const driver = new Driver({
     ...body,
-    id: uuid()
+    id: uuid(),
   });
   db.create(res, driver);
 });
 
 // Update an existing driver
 router.put('/:id', (req, res) => {
-  const { params: { id }, body } = req;
+  const {
+    params: { id },
+    body,
+  } = req;
   db.update(res, Driver, { id }, body, tableName);
 });
 
 // Delete an existing driver
 router.delete('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.deleteById(res, Driver, id, tableName);
 });
 

--- a/server/router/location.ts
+++ b/server/router/location.ts
@@ -10,7 +10,9 @@ const tableName = 'Locations';
 
 // Get a location by id in Locations table
 router.get('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Location, id, tableName);
 });
 
@@ -32,9 +34,7 @@ router.get('/', (req, res) => {
           .not()
           .eq(Tag.CUSTOM);
       } else {
-        condition = condition
-          .where('tag')
-          .eq(Tag.INACTIVE);
+        condition = condition.where('tag').eq(Tag.INACTIVE);
       }
     }
     db.scan(res, Location, condition);
@@ -43,7 +43,9 @@ router.get('/', (req, res) => {
 
 // Put a location in Locations table
 router.post('/', (req, res) => {
-  const { body: { name, address } } = req;
+  const {
+    body: { name, address },
+  } = req;
   const location = new Location({
     id: uuid(),
     name,
@@ -54,7 +56,10 @@ router.post('/', (req, res) => {
 
 // Update an existing location
 router.put('/:id', (req, res) => {
-  const { params: { id }, body } = req;
+  const {
+    params: { id },
+    body,
+  } = req;
   const { address } = body;
   if (address) {
     body.address = formatAddress(address);
@@ -64,7 +69,9 @@ router.put('/:id', (req, res) => {
 
 // Delete an existing location
 router.delete('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.deleteById(res, Location, id, tableName);
 });
 

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -11,7 +11,9 @@ const tableName = 'Rides';
 
 // Get a ride by id in Rides table
 router.get('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Ride, id, tableName);
 });
 
@@ -47,7 +49,14 @@ router.get('/', (req, res) => {
 // Put a ride in Rides table
 router.post('/', (req, res) => {
   const {
-    body: { rider, startTime, requestedEndTime, driver, startLocation, endLocation },
+    body: {
+      rider,
+      startTime,
+      requestedEndTime,
+      driver,
+      startLocation,
+      endLocation,
+    },
   } = req;
 
   let startLocationId;
@@ -92,7 +101,10 @@ router.post('/', (req, res) => {
 
 // Update an existing ride
 router.put('/:id', (req, res) => {
-  const { params: { id }, body } = req;
+  const {
+    params: { id },
+    body,
+  } = req;
   if (body.type === Type.PAST) {
     db.getById(res, Ride, id, tableName, (ride) => {
       const {
@@ -116,7 +128,9 @@ router.put('/:id', (req, res) => {
 
 // Delete an existing ride
 router.delete('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.deleteById(res, Ride, id, tableName);
 });
 

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -11,7 +11,9 @@ const tableName = 'Riders';
 
 // Get a rider by id in Riders table
 router.get('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Rider, id, tableName);
 });
 
@@ -20,20 +22,34 @@ router.get('/', (req, res) => db.getAll(res, Rider, tableName));
 
 // Get profile information for a rider
 router.get('/:id/profile', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Rider, id, tableName, (rider: RiderType) => {
     const {
-      email, firstName, lastName, phoneNumber, pronouns, joinDate,
+      email,
+      firstName,
+      lastName,
+      phoneNumber,
+      pronouns,
+      joinDate,
     } = rider;
     res.send({
-      email, firstName, lastName, phoneNumber, pronouns, joinDate,
+      email,
+      firstName,
+      lastName,
+      phoneNumber,
+      pronouns,
+      joinDate,
     });
   });
 });
 
 // Get accessibility information for a rider
 router.get('/:id/accessibility', async (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Rider, id, tableName, (rider: RiderType) => {
     const { description, accessibility } = rider;
     res.send({ description, accessibility });
@@ -42,7 +58,9 @@ router.get('/:id/accessibility', async (req, res) => {
 
 // Get organization information for a rider
 router.get('/:id/organization', async (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Rider, id, tableName, (rider: RiderType) => {
     const { description, organization } = rider;
     res.send({ description, organization });
@@ -51,7 +69,9 @@ router.get('/:id/organization', async (req, res) => {
 
 // Get all favorite locations for a rider
 router.get('/:id/favorites', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Rider, id, tableName, ({ favoriteLocations }: RiderType) => {
     const keys = createKeys('id', favoriteLocations);
     db.batchGet(res, Location, keys, 'Locations');
@@ -71,29 +91,43 @@ router.post('/', (req, res) => {
 
 // Update a rider in Riders table
 router.put('/:id', (req, res) => {
-  const { params: { id }, body } = req;
+  const {
+    params: { id },
+    body,
+  } = req;
   db.update(res, Rider, { id }, body, tableName);
 });
 
 // Add a location to favorites
 router.post('/:id/favorites', (req, res) => {
-  const { params: { id }, body: { id: locId } } = req;
+  const {
+    params: { id },
+    body: { id: locId },
+  } = req;
   // check if location exists in table
   db.getById(res, Location, locId, 'Locations', () => {
     const operation = { $ADD: { favoriteLocations: [locId] } };
     const condition = new Condition('favoriteLocations').not().contains(locId);
     db.conditionalUpdate(
-      res, Rider, { id }, operation, condition, tableName, ({ favoriteLocations }: RiderType) => {
+      res,
+      Rider,
+      { id },
+      operation,
+      condition,
+      tableName,
+      ({ favoriteLocations }: RiderType) => {
         const keys = createKeys('id', favoriteLocations);
         db.batchGet(res, Location, keys, 'Locations');
-      },
+      }
     );
   });
 });
 
 // Delete an existing rider
 router.delete('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.deleteById(res, Rider, id, tableName);
 });
 

--- a/server/router/vehicle.ts
+++ b/server/router/vehicle.ts
@@ -8,7 +8,9 @@ const tableName = 'Vehicles';
 
 // Get a vehicle by id
 router.get('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.getById(res, Vehicle, id, tableName);
 });
 
@@ -20,20 +22,25 @@ router.post('/', (req, res) => {
   const { body } = req;
   const vehicle = new Vehicle({
     ...body,
-    id: uuid()
+    id: uuid(),
   });
   db.create(res, vehicle);
 });
 
 // Update an existing vehicle
 router.put('/:id', (req, res) => {
-  const { params: { id }, body } = req;
+  const {
+    params: { id },
+    body,
+  } = req;
   db.update(res, Vehicle, { id }, body, tableName);
 });
 
 // Delete an existing vehicle
 router.delete('/:id', (req, res) => {
-  const { params: { id } } = req;
+  const {
+    params: { id },
+  } = req;
   db.deleteById(res, Vehicle, id, tableName);
 });
 


### PR DESCRIPTION
### Summary <!-- Required -->

Motivation: while Eslint keeps good code-quality, it is also important to keep constant and clean formatting.

Updated _package.json_, _eslintrc.json_ to include prettier.

Also added a script, `npm run format` to format all code. (Optionally, this could be added as a Github action).

In this PR, only the server files were formatted as including the frontend would cause too many changed lines.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
1. `npm install`
2. Check over _package.json_, _eslintrc.json_, and _.prettierrc_

### Notes <!-- Optional -->

Installed packages via: `npm install --save-dev @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-airbnb-typescript@6.3.2 eslint-plugin-jest eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-react-hooks eslint-plugin-react prettier eslint-config-prettier eslint-plugin-prettier` (source: [a related medium article](https://medium.com/@smagluf/for-anyone-having-issues-regarding-the-eslint-version-its-due-to-the-fact-that-the-2d2ac1ebfb31)).

Prettier can also be used to format other file types, like JSON. The format script can be updated to include JSON files.

### Breaking Changes  <!-- Optional -->
N/A
