### PR TITLE
Revert populated fields

### DIFF
--- a/server/models/driver.ts
+++ b/server/models/driver.ts
@@ -60,10 +60,7 @@ const schema = new dynamoose.Schema({
     type: Object,
     schema: availabilitySchema,
   },
-  vehicle: {
-    type: Vehicle as any,
-    required: true,
-  },
+  vehicle: Vehicle as any,
   phoneNumber: {
     type: String,
     required: true,

--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -61,14 +61,8 @@ const schema = new dynamoose.Schema({
     default: false,
     required: true,
   },
-  startLocation: {
-    type: Location as any,
-    required: true,
-  },
-  endLocation: {
-    type: Location as any,
-    required: true,
-  },
+  startLocation: Location as any,
+  endLocation: Location as any,
   startTime: {
     type: String,
     required: true,
@@ -83,13 +77,8 @@ const schema = new dynamoose.Schema({
     type: String,
     validate: (time) => isISO8601(time as string),
   },
-  rider: {
-    type: Rider as any,
-    required: true,
-  },
-  driver: {
-    type: Driver as any,
-  },
+  rider: Rider as any,
+  driver: Driver as any,
   recurring: {
     type: Boolean,
     required: true,


### PR DESCRIPTION
### Summary <!-- Required -->
This PR reverts the validation of fields with Model types, as it breaks the populate functionality of Dynamoose.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
