### PR TITLE
Riders end date field

### DIFF
--- a/frontend/src/components/Modal/RiderModal.tsx
+++ b/frontend/src/components/Modal/RiderModal.tsx
@@ -59,6 +59,7 @@ const RiderModal = ({ riders, setRiders }: RiderModalProps) => {
         accessibility: formData.accessibility,
         description: '',
         joinDate: '',
+        endDate: '',
         pronouns: '',
         address: formData.address,
         favoriteLocations: [],

--- a/frontend/src/components/Modal/modal.module.css
+++ b/frontend/src/components/Modal/modal.module.css
@@ -1,5 +1,5 @@
 .background {
-  position: absolute;
+  position: fixed;
   background-color: rgba(13, 13, 13, 0.6);
   top: 0;
   left: 0;

--- a/frontend/src/components/RideModal/RideModal.tsx
+++ b/frontend/src/components/RideModal/RideModal.tsx
@@ -10,17 +10,18 @@ type RideModalProps = {
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>,
   isOpen: boolean,
   setIsOpen:  React.Dispatch<React.SetStateAction<boolean>>,
+  setOpenRideModal?: React.Dispatch<React.SetStateAction<number>>,
   ride?: Ride
 }
 
-const RideModal = ({currentPage, setCurrentPage, isOpen, setIsOpen, ride}: RideModalProps) => {
+const RideModal = ({currentPage, setCurrentPage, isOpen, setIsOpen, setOpenRideModal, ride}: RideModalProps) => {
   const [formData, setFormData] = useState<ObjectType>(
     ride ? 
     {
       date: moment(ride.startTime).format('YYYY-MM-DD'),
       pickupTime: moment(ride.startTime).format('kk:mm'),
       dropoffTime: moment(ride.endTime).format('kk:mm'),
-      driver: ride.driver?.id,
+      driver: ride.driver,
       rider: ride.rider,
       startLocation: ride.startLocation,
       endLocation: ride.endLocation,
@@ -36,7 +37,9 @@ const RideModal = ({currentPage, setCurrentPage, isOpen, setIsOpen, ride}: RideM
   const goPrevPage = () => setCurrentPage((p) => p - 1);
 
   const closeModal = () => {
+    console.log('closing')
     setFormData({});
+    if (setOpenRideModal) setOpenRideModal(-1);
     setIsOpen(false);
   };
 

--- a/frontend/src/components/RideModal/RideModal.tsx
+++ b/frontend/src/components/RideModal/RideModal.tsx
@@ -14,7 +14,14 @@ type RideModalProps = {
   ride?: Ride
 }
 
-const RideModal = ({currentPage, setCurrentPage, isOpen, setIsOpen, setOpenRideModal, ride}: RideModalProps) => {
+const RideModal = ({
+  currentPage, 
+  setCurrentPage, 
+  isOpen, 
+  setIsOpen, 
+  setOpenRideModal, 
+  ride
+}: RideModalProps) => {
   const [formData, setFormData] = useState<ObjectType>(
     ride ? 
     {

--- a/frontend/src/components/TableComponents/TableCell.tsx
+++ b/frontend/src/components/TableComponents/TableCell.tsx
@@ -27,7 +27,9 @@ const TableCell = (props: TableCellProps) => {
         if (outline !== undefined) {
           return (<td key={index} className={`${styles.passInfo} ${styles.cell} 
           ${styles.lastCell}`}>
-            <Button onClick={buttonHandler} outline={outline}>{data} {<ButtonModal />}</Button></td>);
+            <Button onClick={buttonHandler} outline={outline}>
+              {data} {<ButtonModal />}
+            </Button></td>);
         }
         return (<td key={index} className={`${styles.passInfo} ${styles.cell} 
         ${styles.lastCell}`}>

--- a/frontend/src/components/TableComponents/TableCell.tsx
+++ b/frontend/src/components/TableComponents/TableCell.tsx
@@ -11,10 +11,11 @@ type TableCellProps = {
   tag?: string;
   buttonHandler?: () => void;
   ButtonModal?: () => JSX.Element;
+  outline?: boolean;
 }
 
 const TableCell = (props: TableCellProps) => {
-  const { data, index, first, last, tag, buttonHandler, ButtonModal } = props;
+  const { data, index, first, last, tag, buttonHandler, ButtonModal, outline } = props;
   if (first) {
     return (<td
       key={index}
@@ -23,6 +24,11 @@ const TableCell = (props: TableCellProps) => {
     </td>);
   } if (last) {
       if (buttonHandler && ButtonModal) {
+        if (outline !== undefined) {
+          return (<td key={index} className={`${styles.passInfo} ${styles.cell} 
+          ${styles.lastCell}`}>
+            <Button onClick={buttonHandler} outline={outline}>{data} {<ButtonModal />}</Button></td>);
+        }
         return (<td key={index} className={`${styles.passInfo} ${styles.cell} 
         ${styles.lastCell}`}>
           <Button onClick={buttonHandler}>{data} {<ButtonModal />}</Button></td>);

--- a/frontend/src/components/TableComponents/TableRow.tsx
+++ b/frontend/src/components/TableComponents/TableRow.tsx
@@ -28,8 +28,8 @@ const TableRow = (props: TableRowProps) => {
         />
       );
     }
-    if (index === values.length - 1) {
-      /* last cell */
+    if (buttonHandler) {
+      /* if the cell is a button */
       return (
         <TableCell
           key={index}
@@ -39,6 +39,7 @@ const TableRow = (props: TableRowProps) => {
           last={true}
           buttonHandler={buttonHandler}
           ButtonModal={ButtonModal}
+          outline={index !== values.length - 1}
         />
       );
     }

--- a/frontend/src/components/UserTables/RidersTable.tsx
+++ b/frontend/src/components/UserTables/RidersTable.tsx
@@ -62,12 +62,19 @@ const RidersTable = ({ riders, setRiders }: RidersTableProps) => {
         phoneNumber,
         address,
         joinDate,
+        endDate,
         email,
         accessibility,
       } = rider;
       const valuePhone = { data: phoneNumber };
       const valueAddress = { data: address };
-      const valueJoinDate = { data: joinDate };
+      const valueDuration = { 
+        data: 
+          endDate ? 
+          `${joinDate} - ${endDate}` 
+          : 
+          `${joinDate} -`
+        };
       const valueAccessbility = { data: renderAccessNeeds(accessibility) };
       const netId = email.split('@')[0];
       const valueNameNetid = {
@@ -83,7 +90,7 @@ const RidersTable = ({ riders, setRiders }: RidersTableProps) => {
         valueNameNetid,
         valuePhone,
         valueAddress,
-        valueJoinDate,
+        valueDuration,
         valueAccessbility,
       ];
       const riderData = {

--- a/frontend/src/components/UserTables/RidesTable.tsx
+++ b/frontend/src/components/UserTables/RidesTable.tsx
@@ -27,13 +27,13 @@ function renderTableHeader() {
 const RidesTable = (
   { rides, drivers, hasButtons }: RidesTableProps) => {
   const [openAssignModal, setOpenAssignModal] = useState(-1);
+  const [openRideModal, setOpenRideModal] = useState(-1);
   const [currentPage, setCurrentPage] = useState(0);
   const [rideModalIsOpen, setRideModalIsOpen] = useState(false);
 
   function renderTableData(allRides: Ride[]) {
     return allRides.filter(r => r.startLocation !== undefined &&
       r.endLocation !== undefined).map((ride, index) => {
-        console.log(ride)
         const startTime = new Date(ride.startTime).toLocaleTimeString([], {
           hour: '2-digit',
           minute: '2-digit',
@@ -59,6 +59,8 @@ const RidesTable = (
         const valueDropoff = { data: dropoffLocation, tag: dropoffTag };
         const valueNeeds = { data: needs };
         const openRidesModal = () => {
+          console.log('opening')
+          setOpenRideModal(index);
           setCurrentPage(0);
           setRideModalIsOpen(true);
         };
@@ -66,7 +68,7 @@ const RidesTable = (
           <RideModal
             currentPage={currentPage} 
             setCurrentPage={setCurrentPage} 
-            isOpen={rideModalIsOpen}
+            isOpen={openRideModal === index && rideModalIsOpen}
             setIsOpen={setRideModalIsOpen}
             ride={ride}
           />

--- a/frontend/src/components/UserTables/RidesTable.tsx
+++ b/frontend/src/components/UserTables/RidesTable.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import { Driver, Ride } from '../../types/index';
 import AssignDriverModal from '../Modal/AssignDriverModal';
+import RideModal from '../RideModal/RideModal';
 import styles from './table.module.css';
 import TableRow from '../TableComponents/TableRow';
 
 type RidesTableProps = {
   rides: Ride[];
   drivers: Driver[];
-  hasAssignButton: boolean;
+  hasButtons: boolean;
 }
 
 function renderTableHeader() {
@@ -24,12 +25,15 @@ function renderTableHeader() {
 }
 
 const RidesTable = (
-  { rides, drivers, hasAssignButton }: RidesTableProps) => {
-  const [openModal, setOpenModal] = useState(-1);
+  { rides, drivers, hasButtons }: RidesTableProps) => {
+  const [openAssignModal, setOpenAssignModal] = useState(-1);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [rideModalIsOpen, setRideModalIsOpen] = useState(false);
 
   function renderTableData(allRides: Ride[]) {
     return allRides.filter(r => r.startLocation !== undefined &&
       r.endLocation !== undefined).map((ride, index) => {
+        console.log(ride)
         const startTime = new Date(ride.startTime).toLocaleTimeString([], {
           hour: '2-digit',
           minute: '2-digit',
@@ -54,18 +58,37 @@ const RidesTable = (
         const valuePickup = { data: pickupLocation, tag: pickupTag };
         const valueDropoff = { data: dropoffLocation, tag: dropoffTag };
         const valueNeeds = { data: needs };
+        const openRidesModal = () => {
+          setCurrentPage(0);
+          setRideModalIsOpen(true);
+        };
+        const rideModal = () => (
+          <RideModal
+            currentPage={currentPage} 
+            setCurrentPage={setCurrentPage} 
+            isOpen={rideModalIsOpen}
+            setIsOpen={setRideModalIsOpen}
+            ride={ride}
+          />
+        )
         const assignModal = () => (
           <AssignDriverModal
-            isOpen={openModal === index}
-            close={() => setOpenModal(-1)}
+            isOpen={openAssignModal === index}
+            close={() => setOpenAssignModal(-1)}
             ride={rides[0]}
             allDrivers={drivers}
           />
         );
 
+        const editButton = {
+          data: 'Edit',
+          buttonHandler: () => openRidesModal(),
+          ButtonModal: rideModal,
+        };
+
         const assignButton = {
           data: 'Assign',
-          buttonHandler: () => setOpenModal(index),
+          buttonHandler: () => setOpenAssignModal(index),
           ButtonModal: assignModal,
         };
 
@@ -75,11 +98,12 @@ const RidesTable = (
           valueDropoff,
           valueNeeds,
         ];
-        const inputValuesAndButton = [
+        const inputValuesAndButtons = [
           valueName,
           valuePickup,
           valueDropoff,
           valueNeeds,
+          editButton,
           assignButton,
         ];
         return (
@@ -89,8 +113,8 @@ const RidesTable = (
               <span className={styles.bold}>{startTime}</span> <br></br>
               <span className={styles.gray}>-- {endTime}</span>
             </td>
-            {hasAssignButton ?
-              <TableRow values={inputValuesAndButton} /> :
+            {hasButtons ?
+              <TableRow values={inputValuesAndButtons} /> :
               <TableRow values={inputValues} />}
           </tr>
         );

--- a/frontend/src/components/UserTables/ScheduledTable.tsx
+++ b/frontend/src/components/UserTables/ScheduledTable.tsx
@@ -36,7 +36,7 @@ const ScheduledTable = ({ driverId, driverName }: ScheduledTableProp) => {
   return (
     <>
       <h1 className={styles.formHeader}>{driverName}</h1>
-      <RidesTable rides={rides} drivers={[]} hasAssignButton={false} />
+      <RidesTable rides={rides} drivers={[]} hasButtons={false} />
     </>
   );
 };

--- a/frontend/src/components/UserTables/UnscheduledTable.tsx
+++ b/frontend/src/components/UserTables/UnscheduledTable.tsx
@@ -25,10 +25,7 @@ const Table = ({ drivers }: TableProps) => {
 
   useEffect(() => {
     const today = moment(curDate).format('YYYY-MM-DD');
-    const dayWithRides = new Date();
-    dayWithRides.setDate(dayWithRides.getDate() - 3);
-    const day = moment(dayWithRides).format('YYYY-MM-DD');
-    fetch(`/api/rides?type=unscheduled&date=${day}`, withDefaults())
+    fetch(`/api/rides?type=unscheduled&date=${today}`, withDefaults())
       .then((res) => res.json())
       .then(({ data }) => setRides(data.sort(compRides)));
   }, [withDefaults, curDate]);

--- a/frontend/src/components/UserTables/UnscheduledTable.tsx
+++ b/frontend/src/components/UserTables/UnscheduledTable.tsx
@@ -25,7 +25,10 @@ const Table = ({ drivers }: TableProps) => {
 
   useEffect(() => {
     const today = moment(curDate).format('YYYY-MM-DD');
-    fetch(`/api/rides?type=unscheduled&date=${today}`, withDefaults())
+    const dayWithRides = new Date();
+    dayWithRides.setDate(dayWithRides.getDate() - 3);
+    const day = moment(dayWithRides).format('YYYY-MM-DD');
+    fetch(`/api/rides?type=unscheduled&date=${day}`, withDefaults())
       .then((res) => res.json())
       .then(({ data }) => setRides(data.sort(compRides)));
   }, [withDefaults, curDate]);
@@ -33,7 +36,7 @@ const Table = ({ drivers }: TableProps) => {
   return (
     <>
       <h1 className={styles.formHeader}>Unscheduled Rides</h1>
-      <RidesTable rides={rides} drivers={drivers} hasAssignButton={true} />
+      <RidesTable rides={rides} drivers={drivers} hasButtons={true} />
     </>
   );
 };

--- a/frontend/src/pages/Dashboard/Home.tsx
+++ b/frontend/src/pages/Dashboard/Home.tsx
@@ -5,6 +5,7 @@ import RideModal from '../../components/RideModal/RideModal';
 import UnscheduledTable from '../../components/UserTables/UnscheduledTable';
 import Schedule from '../../components/Schedule/Schedule';
 import MiniCal from '../../components/MiniCal/MiniCal';
+import { Button } from '../../components/FormElements/FormElements';
 import styles from './page.module.css';
 import { Driver } from '../../types/index';
 import { useReq } from '../../context/req';
@@ -14,6 +15,10 @@ import ExportButton from '../../components/ExportButton/ExportButton';
 const Home = () => {
   const [drivers, setDrivers] = useState<Driver[]>([]);
   const { withDefaults } = useReq();
+
+  // states for the rides model
+  const [currentPage, setCurrentPage] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
 
   const [downloadData, setDownloadData] = useState<string>('');
   const csvLink = useRef<CSVLink & HTMLAnchorElement & { link: HTMLAnchorElement }>(null);
@@ -30,6 +35,11 @@ const Home = () => {
 
     fetchDrivers();
   }, [withDefaults]);
+
+  const openRidesModal = () => {
+    setCurrentPage(0);
+    setIsOpen(true);
+  };
 
   const downloadCSV = () => {
     fetch(`/api/rides/download?date=${today}`, withDefaults())
@@ -59,7 +69,13 @@ const Home = () => {
             ref={csvLink}
             target='_blank'
           />
-          <RideModal />
+          <Button onClick={openRidesModal}>+ Add ride</Button> 
+          <RideModal 
+            currentPage={currentPage} 
+            setCurrentPage={setCurrentPage} 
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+          />
         </div>
       </div>
       <MiniCal />

--- a/frontend/src/pages/Dashboard/Students.tsx
+++ b/frontend/src/pages/Dashboard/Students.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
+import { NewRider } from '../../types';
 import RidersTable from '../../components/UserTables/RidersTable';
 import RiderModal from '../../components/Modal/RiderModal';
 import styles from './page.module.css';
 
 const Riders = () => {
-  const [riders, setRiders] = useState(
+  const [riders, setRiders] = useState<NewRider[]>(
     [
       {
         id: '',
@@ -15,6 +16,7 @@ const Riders = () => {
         accessibility: new Array<string>(),
         description: '',
         joinDate: '',
+        endDate: '',
         pronouns: '',
         address: '',
         favoriteLocations: new Array<string>(),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -29,6 +29,7 @@ export type NewRider = {
   accessibility: Array<string>;
   description: string;
   joinDate: string;
+  endDate: string;
   address: string;
   favoriteLocations: Array<string>;
   organization: string;

--- a/server/models/rider.ts
+++ b/server/models/rider.ts
@@ -24,6 +24,7 @@ export type RiderType = {
   organization: Organization
   description: string
   joinDate: string
+  endDate: string
   pronouns: string
   address: string
   favoriteLocations: string[]
@@ -69,6 +70,11 @@ const schema = new dynamoose.Schema({
     required: true,
   },
   joinDate: {
+    type: String,
+    required: true,
+    validate: /^(0[1-9]|1[012])\/(0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/,
+  },
+  endDate: {
     type: String,
     required: true,
     validate: /^(0[1-9]|1[012])\/(0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/,

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -27,10 +27,10 @@ router.get('/:id/profile', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Rider, id, tableName, (rider: RiderType) => {
     const {
-      email, firstName, lastName, phoneNumber, pronouns, joinDate,
+      email, firstName, lastName, phoneNumber, pronouns, joinDate, endDate,
     } = rider;
     res.send({
-      email, firstName, lastName, phoneNumber, pronouns, joinDate,
+      email, firstName, lastName, phoneNumber, pronouns, joinDate, endDate,
     });
   });
 });


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds an `endDate` field to Riders on both the frontend and the backend.
![image](https://user-images.githubusercontent.com/60638132/111247073-c4be3b00-85dd-11eb-8cf5-59cec9126ea5.png)


### Test Plan <!-- Required -->

For now we can only go on the riders page and check the duration cell. However, because the riders added in the past didn't have the endDate field it's hard to see if the code works. In my next PR I will fix the issues with the rider modal so that we can add new riders with endDate and do full testing.
