### PR TITLE
Surround Tables on Home with Collapsible Component

### DIFF
--- a/frontend/src/components/Collapsible/collapsible.module.css
+++ b/frontend/src/components/Collapsible/collapsible.module.css
@@ -26,5 +26,4 @@
   display: inline-block;
   width: 100%;
   background-color: #ffffff;
-  /* padding: 0.625rem 0 0.625rem 5rem; */
 }

--- a/frontend/src/components/Collapsible/collapsible.module.css
+++ b/frontend/src/components/Collapsible/collapsible.module.css
@@ -26,5 +26,5 @@
   display: inline-block;
   width: 100%;
   background-color: #ffffff;
-  padding: 0.625rem 0 0.625rem 5rem;
+  /* padding: 0.625rem 0 0.625rem 5rem; */
 }

--- a/frontend/src/components/UserTables/UnscheduledTable.tsx
+++ b/frontend/src/components/UserTables/UnscheduledTable.tsx
@@ -32,7 +32,6 @@ const Table = ({ drivers }: TableProps) => {
 
   return (
     <>
-      <h1 className={styles.formHeader}>Unscheduled Rides</h1>
       <RidesTable rides={rides} drivers={drivers} hasAssignButton={true} />
     </>
   );

--- a/frontend/src/pages/Dashboard/Home.tsx
+++ b/frontend/src/pages/Dashboard/Home.tsx
@@ -10,6 +10,7 @@ import { useEmployees } from '../../context/EmployeesContext';
 import ExportButton from '../../components/ExportButton/ExportButton';
 import { useReq } from '../../context/req';
 import { useDate } from '../../context/date';
+import Collapsible from 'components/Collapsible/Collapsible';
 
 const Home = () => {
   const {drivers} = useEmployees();
@@ -53,7 +54,9 @@ const Home = () => {
       </div>
       <MiniCal />
       <Schedule />
-      <UnscheduledTable drivers={drivers} />
+      <Collapsible title={"Unscheduled Rides"}>
+        <UnscheduledTable drivers={drivers} />
+      </Collapsible>
     </div>
   );
 };

--- a/frontend/src/pages/Dashboard/Home.tsx
+++ b/frontend/src/pages/Dashboard/Home.tsx
@@ -10,10 +10,10 @@ import { useEmployees } from '../../context/EmployeesContext';
 import ExportButton from '../../components/ExportButton/ExportButton';
 import { useReq } from '../../context/req';
 import { useDate } from '../../context/date';
-import Collapsible from 'components/Collapsible/Collapsible';
+import Collapsible from '../../components/Collapsible/Collapsible';
 
 const Home = () => {
-  const {drivers} = useEmployees();
+  const { drivers } = useEmployees();
   const { withDefaults } = useReq();
 
   const [downloadData, setDownloadData] = useState<string>('');
@@ -25,7 +25,7 @@ const Home = () => {
     fetch(`/api/rides/download?date=${today}`, withDefaults())
       .then((res) => res.text())
       .then((data) => {
-        if (data==='') {
+        if (data === '') {
           setDownloadData('Name,Pick Up,From,To,Drop Off,Needs,Driver');
         } else {
           setDownloadData(data);
@@ -54,7 +54,7 @@ const Home = () => {
       </div>
       <MiniCal />
       <Schedule />
-      <Collapsible title={"Unscheduled Rides"}>
+      <Collapsible title={'Unscheduled Rides'}>
         <UnscheduledTable drivers={drivers} />
       </Collapsible>
     </div>


### PR DESCRIPTION
### Summary 

This pull request added a feature to the unscheduled ride component to make them collapsible.

- [x] Wrapped unscheduled rides in collapsible component
- [x] Removed previous header from unscheduled rides table and moved to collapsible component

### Test Plan <!-- Required -->

![2021-04-01-115454_1920x1080_scrot](https://user-images.githubusercontent.com/3797852/113321046-32a67a00-92e1-11eb-8300-d412f7900e58.png)

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

I removed the padding from the collapsible component to make it look like the design spec.


