### PR TITLE
Implement get all repeating rides endpoint

### DIFF
--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -128,7 +128,7 @@ const schema = new dynamoose.Schema({
   endDate: {
     type: String,
     required: false,
-    validate: /^(0[1-9]|1[012])\/(0[1-9]|[12][0-9]|3[01])\/(19|20)\d{2}$/,
+    validate: /^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/,
   },
 });
 

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -55,9 +55,7 @@ router.get('/repeating', validateUser('User'), (req, res) => {
   let condition = new Condition('recurring')
     .eq(true)
     .where('endDate')
-    .ge(now.substring(0, 10))
-    .where('startTime')
-    .le(now);
+    .ge(now.substring(0, 10));
   if (rider) {
     condition = condition.where('rider').eq(rider);
   }

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -48,6 +48,22 @@ router.get('/download', (req, res) => {
   db.scan(res, Ride, condition, callback);
 });
 
+// Get and query all master repeating rides in table
+router.get('/repeating', validateUser('User'), (req, res) => {
+  const { query: { rider } } = req;
+  const now = moment().toISOString();
+  let condition = new Condition('recurring')
+    .eq(true)
+    .where('endDate')
+    .ge(now.substring(0, 10))
+    .where('startTime')
+    .le(now);
+  if (rider) {
+    condition = condition.where('rider').eq(rider);
+  }
+  db.scan(res, Ride, condition);
+});
+
 // Get a ride by id in Rides table
 router.get('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request creates a get all repeating rides endpoint, to help retrieve master repeating rides that have already occurred, but are still repeating.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->


The `endDate` field is now formatted as YYYY-MM-DD, to fix bugs when comparing times.
