### PR TITLE
Stats Table Model

### DIFF
--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -15,12 +15,12 @@ export type StatsType = {
 
 const schema = new dynamoose.Schema({
   year: {
-    type: Number,
+    type: String,
     required: true,
     hashKey: true,
   },
   monthDay: {
-    type: Number,
+    type: String,
     required: true,
     rangeKey: true,
   },
@@ -61,7 +61,8 @@ const schema = new dynamoose.Schema({
   },
   drivers: {
     type: Object,
+    required: true,
   },
-});
+}, { saveUnknown: ['drivers.*'] });
 
 export const Stats = dynamoose.model('Stats', schema, { create: false });

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -1,16 +1,18 @@
 import dynamoose from 'dynamoose';
 
 export type StatsType = {
-  year: number,
-  monthDay: number,
+  year: string,
+  monthDay: string,
   dayCount: number,
   dayNoShow: number,
   dayCancel: number,
   nightCount: number,
   nightNoShow: number,
   nightCancel: number,
-  dailyTotal: number
-  drivers: Object,
+  dailyTotal: number,
+  drivers: {
+    [name: string]: number
+  },
 };
 
 const schema = new dynamoose.Schema({

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -1,0 +1,67 @@
+import dynamoose from 'dynamoose';
+
+export type StatsType = {
+  year: number,
+  monthDay: number,
+  dayCount: number,
+  dayNoShow: number,
+  dayCancel: number,
+  nightCount: number,
+  nightNoShow: number,
+  nightCancel: number,
+  dailyTotal: number
+  drivers: Object,
+};
+
+const schema = new dynamoose.Schema({
+  year: {
+    type: Number,
+    required: true,
+    hashKey: true,
+  },
+  monthDay: {
+    type: Number,
+    required: true,
+    rangeKey: true,
+  },
+  dayCount: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  dayNoShow: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  dayCancel: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  nightCount: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  nightNoShow: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  nightCancel: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  dailyTotal: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  drivers: {
+    type: Object,
+  },
+});
+
+export const Stats = dynamoose.model('Stats', schema, { create: false });


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds the model for the Stats table, following this schema https://docs.google.com/document/d/1N_p_0rVIuMqsHOXdGtwcRFu7tjKmT_ml8eLN-eN7y1c/edit

### Notes <!-- Optional -->
- Partition/hash key = "year"
- Sort/range key = "monthDay"
- The "drivers" Object field has no schema validation but should follow { [driver]: number of rides given on day, }

