### PR TITLE
created new SRLabel

### DIFF
--- a/frontend/src/components/FormElements/FormElements.tsx
+++ b/frontend/src/components/FormElements/FormElements.tsx
@@ -12,6 +12,14 @@ export const Label = ({ className, children, ...props }: LabelType) => (
   </label>
 );
 
+//This should only be used when you don't want a label to visually appear on screen
+//Source: https://webaim.org/techniques/css/invisiblecontent/#techniques
+export const SRLabel = ({ className, children, ...props }: LabelType) => (
+  <label {...props} className={cn(styles.srlabel, className)}>
+    {children}
+  </label>
+);
+
 type InputType = (
   React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>
 );

--- a/frontend/src/components/FormElements/formelements.module.css
+++ b/frontend/src/components/FormElements/formelements.module.css
@@ -61,3 +61,14 @@
   border: 0.063rem solid #000000;
   box-sizing: border-box;
 }
+.srlabel{
+  border: 0;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px; 
+}


### PR DESCRIPTION
### Summary <!-- Required -->

This is a new label created solely for accessibility purposes. It uses the clipping method detailed https://webaim.org/techniques/css/invisiblecontent/#techniques. The label won't be visible in the actual project but will be read aloud in the screen reader. This uses the first method of labelling form inputs where it uses an htmlFor and an input ID. if you need to use this for a group of IDs, add the aria-labelledby to the group of inputs and it should override the htmlFor

- [x] implemented SRLabel
- [ ] fixed Y

### Test Plan <!-- Required -->

There aren't really any screenshots here because it's not visible. In a different branch (accessibility-fixes) this does not show in the employeeModal when used but was read aloud in the screen reader. 
### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
