### PR TITLE
Change repeating ride schema

### DIFF
--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -42,7 +42,7 @@ export type RideType = {
   recurring: boolean,
   recurringDays?: number[],
   endDate?: string
-  deleted?: boolean,
+  deleted?: Set<string>,
   edits?: string[],
 };
 
@@ -115,7 +115,10 @@ const schema = new dynamoose.Schema({
     type: Array,
     schema: [Number],
   },
-  deleted: Boolean,
+  deleted: {
+    type: Set,
+    schema: [String],
+  },
   edits: {
     type: Array,
     schema: [String],

--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -42,7 +42,7 @@ export type RideType = {
   recurring: boolean,
   recurringDays?: number[],
   endDate?: string
-  deleted?: Set<string>,
+  deleted?: string[],
   edits?: string[],
 };
 
@@ -116,7 +116,7 @@ const schema = new dynamoose.Schema({
     schema: [Number],
   },
   deleted: {
-    type: Set,
+    type: Array,
     schema: [String],
   },
   edits: {

--- a/server/router/common.ts
+++ b/server/router/common.ts
@@ -131,17 +131,14 @@ export function deleteById(
   model: ModelType<Document>,
   id: string | ObjectType,
   table: string,
-  callback?: (value: any) => void,
 ) {
   model.get(id, (err, data) => {
     if (err) {
       res.status(err.statusCode || 500).send({ err: err.message });
     } else if (!data) {
       res.status(400).send({ err: `id not found in ${table}` });
-    } else if (callback) {
-      data.populate().then((doc) => callback(doc));
     } else {
-      data.populate().then((doc) => res.status(200).send({ id: doc.toJSON().id }));
+      data.delete().then(() => res.status(200).send({ id }));
     }
   });
 }

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -139,6 +139,7 @@ router.post('/', validateUser('User'), (req, res) => {
       startLocation: startLocationObj ?? startLocation,
       endLocation: endLocationObj ?? endLocation,
       edits: recurring ? [] : undefined,
+      deleted: recurring ? [] : undefined,
     });
     db.create(res, ride);
   }

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -56,11 +56,11 @@ router.get('/download', (req, res) => {
 // Get and query all master repeating rides in table
 router.get('/repeating', validateUser('User'), (req, res) => {
   const { query: { rider } } = req;
-  const now = moment.tz('America/New_York').toISOString();
+  const now = moment.tz('America/New_York').format('YYYY-MM-DD');
   let condition = new Condition('recurring')
     .eq(true)
     .where('endDate')
-    .ge(now.substring(0, 10));
+    .ge(now);
   if (rider) {
     condition = condition.where('rider').eq(rider);
   }

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -6,7 +6,7 @@ import moment from 'moment-timezone';
 import * as db from './common';
 import { Ride, RideLocation, Type } from '../models/ride';
 import { Tag } from '../models/location';
-import { validateUser } from '../util';
+import { createKeys, validateUser } from '../util';
 import { DriverType } from '../models/driver';
 import { RiderType } from '../models/rider';
 
@@ -154,7 +154,22 @@ router.put('/:id', validateUser('User'), (req, res) => {
 // Delete an existing ride
 router.delete('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
-  db.deleteById(res, Ride, id, tableName);
+  db.getById(res, Ride, id, tableName, (ride) => {
+    const { recurring, edits } = ride;
+    const deleteRide = () => {
+      Ride.delete(id)
+        .then(() => res.send({ id }))
+        .catch((err) => res.status(500).send({ err: err.message }));
+    };
+    if (recurring) {
+      const ids = createKeys('id', edits);
+      Ride.batchDelete(ids)
+        .then(deleteRide)
+        .catch((err) => res.status(500).send({ err: err.message }));
+    } else {
+      deleteRide();
+    }
+  });
 });
 
 export default router;

--- a/server/util/repeatingRide.ts
+++ b/server/util/repeatingRide.ts
@@ -49,9 +49,7 @@ function createRepeatingRides() {
         endLocation: endLocation.id ?? endLocation,
       });
 
-      ride.save()
-        .then((doc) => console.log(doc.toJSON()))
-        .catch((err) => console.log(err));
+      ride.save().catch((err) => console.log(err));
     });
   });
 }

--- a/server/util/repeatingRide.ts
+++ b/server/util/repeatingRide.ts
@@ -2,7 +2,6 @@ import { v4 as uuid } from 'uuid';
 import moment from 'moment';
 import { Condition } from 'dynamoose';
 import schedule from 'node-schedule';
-import { AnyDocument } from 'dynamoose/dist/Document';
 import { Ride, RideType } from '../models/ride';
 
 export default function initSchedule() {
@@ -12,104 +11,47 @@ export default function initSchedule() {
   });
 }
 
-
 function createRepeatingRides() {
-  let tomorrowDate = moment(new Date());
-  tomorrowDate = tomorrowDate.add(1, 'days');
+  const tomorrowDate = moment().add(1, 'days');
   const tomorrowDateOnly = tomorrowDate.format('YYYY-MM-DD');
-
   const tomorrowDay = tomorrowDate.weekday();
 
   // condition: recurring ride that includes tomorrowDay
   const condition = new Condition()
     .where('recurring')
     .eq(true)
-    .and()
     .where('recurringDays')
-    .contains(tomorrowDay);
+    .contains(tomorrowDay)
+    .where('endDate')
+    .ge(tomorrowDateOnly)
+    .where('deleted')
+    .not()
+    .contains(tomorrowDateOnly);
 
   Ride.scan(condition).exec((_, data) => {
-    data?.forEach(async (masterRide) => {
+    data?.forEach((masterRide) => {
       const {
-        id, rider, driver, startLocation, endLocation, startTime, endTime, endDate, edits,
+        rider, startLocation, endLocation, startTime, endTime,
       } = masterRide.toJSON() as RideType;
 
-      // get startDate
-      const startDate = moment(startTime).format('YYYY-MM-DD');
+      const newStartTimeOnly = moment(startTime).format('HH:mm:ss');
+      const newStartTime = moment(`${tomorrowDateOnly}T${newStartTimeOnly}`).toISOString();
 
-      // only continue if tomorrow is between the startDate and endDate
-      if (endDate && endDate >= tomorrowDateOnly && startDate <= tomorrowDateOnly) {
-        const newStartTimeOnly = moment(startTime).format('HH:mm:ss');
-        const newStartTime = moment(`${tomorrowDateOnly}T${newStartTimeOnly}`).toISOString();
+      const newEndTimeOnly = moment(endTime).format('HH:mm:ss');
+      const newEndTime = moment(`${tomorrowDateOnly}T${newEndTimeOnly}`).toISOString();
 
-        const newEndTimeOnly = moment(endTime).format('HH:mm:ss');
-        const newEndTime = moment(`${tomorrowDateOnly}T${newEndTimeOnly}`).toISOString();
+      const ride = new Ride({
+        id: uuid(),
+        startTime: newStartTime,
+        endTime: newEndTime,
+        rider,
+        startLocation: startLocation.id ?? startLocation,
+        endLocation: endLocation.id ?? endLocation,
+      });
 
-        const repeatingRide = new Ride({
-          id: uuid(),
-          rider,
-          startLocation,
-          endLocation,
-          startTime: newStartTime,
-          requestedEndTime: newEndTime,
-          endTime: newEndTime,
-          driver,
-          recurring: false,
-        });
-
-        if (edits?.length) {
-          handleEdits(edits, tomorrowDateOnly, repeatingRide, startDate, masterRide);
-        } else if (tomorrowDateOnly !== startDate) {
-          // create repeating ride if no edits and not first occurrence
-          repeatingRide.save().catch((err) => console.log(err));
-        }
-      }
-    });
-  });
-}
-
-function handleEdits(
-  edits: string[],
-  tomorrowDateOnly: string,
-  repeatingRide: AnyDocument,
-  startDate: string,
-  masterRide: AnyDocument,
-) {
-  const seenEdits: string[] = [];
-  let editCount = 0;
-  const numEdits = edits.length;
-
-  edits.forEach(async (editId) => {
-    Ride.get(editId).then(async (editRide) => {
-      const editDate = moment(editRide.startTime);
-      const editDateOnly = moment(editDate).format('YYYY-MM-DD');
-
-      // only look at edits that match tomorrow's date
-      if (editDateOnly === tomorrowDateOnly) {
-        seenEdits.push(editId);
-        // if deleted = true, remove the edit instance
-        if (editRide.deleted) {
-          Ride.get(editId).then((dataGetToDelete) => {
-            dataGetToDelete?.delete();
-          });
-        }
-        // if deleted = false, keep the edit instance as a valid ride
-      }
-      editCount += 1;
-      if (editCount === numEdits) {
-        // create repeating ride if no edits for tomorrow and not first occurrence
-        if (seenEdits.length === 0) {
-          if (tomorrowDateOnly !== startDate) {
-            repeatingRide.save().catch((err) => console.log(err));
-          }
-        // otherwise, remove the seen edits from the master ride
-        } else {
-          const newEdits = await masterRide.edits.filter((id: string) => !(seenEdits.includes(id)));
-          const operation = { $SET: { edits: newEdits } };
-          const keyId = masterRide.id;
-          Ride.update({ id: keyId }, operation);
-        }
-      }
+      ride.save()
+        .then((doc) => console.log(doc.toJSON()))
+        .catch((err) => console.log(err));
     });
   });
 }

--- a/server/util/repeatingRide.ts
+++ b/server/util/repeatingRide.ts
@@ -16,12 +16,13 @@ function createRepeatingRides() {
   const tomorrowDateOnly = tomorrowDate.format('YYYY-MM-DD');
   const tomorrowDay = tomorrowDate.weekday();
 
-  // condition: recurring ride that includes tomorrowDay
   const condition = new Condition()
     .where('recurring')
     .eq(true)
     .where('recurringDays')
     .contains(tomorrowDay)
+    .where('startTime')
+    .le(tomorrowDate.toISOString())
     .where('endDate')
     .ge(tomorrowDateOnly)
     .where('deleted')


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request revises the repeating ride schema to change `deleted` from a boolean to an array. Since deleted rides are only checked by date, not creating them and only storing the dates will reduce the amount of work needed for the frontend to figure out how to display repeating rides.

In addition, delete operations are fixed, and the DELETE ride endpoint now deletes all edits for a repeating ride.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Create a repeating ride, and run the createRepeatingRides function in repeatingRide.ts

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

Because this changes how repeating rides are being displayed, the frontend should account for these changes after this PR merges.
