### PR TITLE
fix incorrect today and tomorrow values on mini cal

### DIFF
--- a/frontend/src/components/MiniCal/MiniCal.tsx
+++ b/frontend/src/components/MiniCal/MiniCal.tsx
@@ -6,9 +6,14 @@ import './datepicker_override.css';
 import styles from './minical.module.css';
 import { useDate } from '../../context/date';
 
-const isToday = (date: Date) => date.getDate() === new Date().getDate();
+const currentDate = new Date(); 
+const isToday = (date: Date) => date.getDate() === currentDate.getDate() && 
+  date.getMonth() == currentDate.getMonth() && 
+  date.getFullYear() == currentDate.getFullYear();
 
-const isTomorrow = (date: Date) => date.getDate() === new Date().getDate() + 1;
+const isTomorrow = (date: Date) =>  date.getDate() === currentDate.getDate() + 1 && 
+  date.getMonth() == currentDate.getMonth() && 
+  date.getFullYear() == currentDate.getFullYear();
 
 const Icon = () => (
   <svg


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes an issue with the mini cal. In the mini cal, because it checked if it was "today" or "tomorrow" based on the number in the day only so if today was April 22, going to March 22 or any other month/year with the day being 22 would also make it be "today". 

- [] implemented X
- [x] fixed Mini Cal

### Test Plan <!-- Required -->

I tested the calendar by going to a different month with the day being 22 and a different year and ensured that the value was correct. I also tested the "today" and "tomorrow" buttons to ensure correctness. 
Correct Day
<img width="960" alt="fix_mini_cal_apr_22" src="https://user-images.githubusercontent.com/32024811/115799213-fdec8680-a3a5-11eb-968d-f250a464512f.png">
Different month
<img width="960" alt="fix_mini_cal_apr_22_corr" src="https://user-images.githubusercontent.com/32024811/115799222-00e77700-a3a6-11eb-9087-e888c36e1d80.png">
Different year
<img width="960" alt="fix_mini_cal_apr_22_check_year" src="https://user-images.githubusercontent.com/32024811/115799230-047afe00-a3a6-11eb-9d49-8e12b4fc94af.png">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
