### PR TITLE
Get stats endpoint

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -12,6 +12,7 @@ import vehicle from './router/vehicle';
 import location from './router/location';
 import upload from './router/upload';
 import auth from './router/auth';
+import stats from './router/stats';
 import initSchedule from './util/repeatingRide';
 import notification from './router/notification';
 
@@ -33,6 +34,7 @@ app.use('/api/locations', location);
 app.use('/api/auth', auth);
 app.use('/api/upload', upload);
 app.use('/api/notification', notification);
+app.use('/api/stats', stats);
 app.get('/api/health-check', (_, response) => response.status(200).send('OK'));
 
 // Serve static files from frontend

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -9,7 +9,6 @@ export type StatsType = {
   nightCount: number,
   nightNoShow: number,
   nightCancel: number,
-  dailyTotal: number,
   drivers: {
     [name: string]: number
   },
@@ -52,11 +51,6 @@ const schema = new dynamoose.Schema({
     default: 0,
   },
   nightCancel: {
-    type: Number,
-    required: true,
-    default: 0,
-  },
-  dailyTotal: {
     type: Number,
     required: true,
     default: 0,

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -1,0 +1,129 @@
+import express, { Response } from 'express';
+import moment from 'moment-timezone';
+import { Condition } from 'dynamoose/dist/Condition';
+import { AnyDocument } from 'dynamoose/dist/Document';
+import { Stats } from '../models/stats';
+import { Ride } from '../models/ride';
+import * as db from './common';
+import { validateUser } from '../util';
+import { Driver, DriverType } from '../models/driver';
+
+const router = express.Router();
+const tableName = 'Stats';
+
+router.get('/:from/:to', (req, res) => {
+  const { params: { from, to } } = req;
+
+  let date = from;
+  while (date <= to) {
+    const year = moment.tz(date, 'YYYY-MM-DD', 'America/New_York').format('YYYY');
+    const monthDay = moment.tz(date, 'YYYY-MM-DD', 'America/New_York').format('MMDD');
+    const condition = new Condition()
+      .where('year')
+      .eq(year)
+      .and()
+      .where('monthDay')
+      .eq(monthDay);
+
+    const dateMoment = moment.tz(date, 'America/New_York');
+    // day = 12am to 5:00pm
+    const dayStart = dateMoment.toISOString();
+    const dayEnd = dateMoment.add(17, 'hours').toISOString();
+    // night = 5:01pm to 11:59:59pm
+    const nightStart = moment.tz(dayEnd, 'America/New_York').add(1, 'seconds').toISOString();
+    const nightEnd = moment.tz(date as string, 'America/New_York').endOf('day').toISOString();
+
+    db.scan(res, Stats, condition, async (data: Document[]) => {
+      if (data.length) {
+        res.send(data);
+      } else {
+        const conditionRidesDay = new Condition()
+          .where('startTime')
+          .between(dayStart, dayEnd)
+          .where('type')
+          .not()
+          .eq('unscheduled')
+          .where('status')
+          .eq('completed');
+
+        const conditionRidesDayNoShow = new Condition()
+          .where('startTime')
+          .between(dayStart, dayEnd)
+          .where('type')
+          .not()
+          .eq('unscheduled')
+          .where('status')
+          .eq('no_show');
+
+        const conditionRidesNight = new Condition()
+          .where('startTime')
+          .between(nightStart, nightEnd)
+          .where('type')
+          .not()
+          .eq('unscheduled')
+          .where('status')
+          .eq('completed');
+
+        const conditionRidesNightNoShow = new Condition()
+          .where('startTime')
+          .between(nightStart, nightEnd)
+          .where('type')
+          .not()
+          .eq('unscheduled')
+          .where('status')
+          .eq('no_show');
+
+        db.scan(res, Ride, conditionRidesDay, ((dataDay: Document[]) => {
+          const dayCountStat = dataDay.length;
+
+          db.scan(res, Ride, conditionRidesDayNoShow, ((dataDayNoShow: Document[]) => {
+            const dayNoShowStat = dataDayNoShow.length;
+
+            db.scan(res, Ride, conditionRidesNight, ((dataNight: Document[]) => {
+              const nightCountStat = dataNight.length;
+
+              db.scan(res, Ride, conditionRidesNightNoShow, ((dataNightNoShow: Document[]) => {
+                const nightNoShowStat = dataNightNoShow.length;
+
+                const driversStat: {[name: string]: number } = {};
+                db.getAll(res, Driver, 'Drivers', async (driversData) => {
+                  driversData.forEach((driverData: DriverType) => {
+                    const driverName = `${driverData.firstName} ${driverData.lastName}`;
+                    const conditionRidesDriver = new Condition()
+                      .where('startTime')
+                      .between(dayStart, nightEnd)
+                      .where('type')
+                      .not()
+                      .eq('unscheduled')
+                      .where('driver')
+                      .eq(driverData);
+
+                    db.scan(res, Ride, conditionRidesDriver, (dataDriver: Document[]) => {
+                      driversStat[driverName] = dataDriver.length;
+                    });
+                  });
+                  const stats = new Stats({
+                    year,
+                    monthDay,
+                    dayCount: dayCountStat,
+                    dayNoShow: dayNoShowStat,
+                    dayCancel: 0,
+                    nightCount: nightCountStat,
+                    nightNoShow: nightNoShowStat,
+                    nightCancel: 0,
+                    drivers: driversStat,
+                  });
+                  Stats.create(stats);
+                  res.send(stats);
+                });
+              }));
+            }));
+          }));
+        }));
+      }
+    });
+    date = moment.tz(date, 'America/New_York').add(1, 'days').format('YYYY-MM-DD');
+  }
+});
+
+export default router;

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -120,7 +120,7 @@ function computeStats(
         });
       });
     } else {
-      console.log('oh no');
+      console.log('Should be unreachable');
     }
   });
 }

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -1,12 +1,10 @@
 import express, { Response } from 'express';
 import moment from 'moment-timezone';
 import { Condition } from 'dynamoose/dist/Condition';
-import { Stats } from '../models/stats';
-import { Ride, RideType } from '../models/ride';
+import { Stats, StatsType } from '../models/stats';
+import { Ride, RideType, Status } from '../models/ride';
 import * as db from './common';
 import { validateUser } from '../util';
-import { Driver, DriverType } from '../models/driver';
-import { RiderType } from '../models/rider';
 
 const router = express.Router();
 const tableName = 'Stats';
@@ -15,25 +13,20 @@ router.get('/', validateUser('User'), (req, res) => {
   const { query: { from, to } } = req;
 
   let date = moment.tz(from, 'America/New_York').format('YYYY-MM-DD');
-  let endDate = date;
   const dates = [date];
   if (to) {
     date = moment.tz(date, 'America/New_York').add(1, 'days').format('YYYY-MM-DD');
-    endDate = moment.tz(to, 'America/New_York').format('YYYY-MM-DD');
     while (date <= to) {
       dates.push(date);
       date = moment.tz(date, 'America/New_York').add(1, 'days').format('YYYY-MM-DD');
     }
   }
+
+  const statsAcc: StatsType[] = [];
+
   dates.forEach((currDate) => {
     const year = moment.tz(currDate, 'YYYY-MM-DD', 'America/New_York').format('YYYY');
     const monthDay = moment.tz(currDate, 'YYYY-MM-DD', 'America/New_York').format('MMDD');
-    const condition = new Condition()
-      .where('year')
-      .eq(year)
-      .and()
-      .where('monthDay')
-      .eq(monthDay);
 
     const dateMoment = moment.tz(currDate, 'America/New_York');
     // day = 12am to 5:00pm
@@ -43,30 +36,38 @@ router.get('/', validateUser('User'), (req, res) => {
     const nightStart = moment.tz(dayEnd, 'America/New_York').add(1, 'seconds').toISOString();
     const nightEnd = moment.tz(currDate as string, 'America/New_York').endOf('day').toISOString();
 
-    computeStats(res, condition, dayStart, dayEnd, nightStart, nightEnd, year,
-      monthDay, currDate, endDate);
+    computeStats(
+      res, statsAcc, dates.length, dayStart, dayEnd, nightStart, nightEnd, year, monthDay,
+    );
   });
 });
 
+function checkSend(
+  res: Response,
+  statsAcc: StatsType[],
+  numDays: number,
+) {
+  if (statsAcc.length === numDays) {
+    res.send(statsAcc);
+  }
+}
+
 function computeStats(
   res: Response,
-  condition: Condition,
+  statsAcc: StatsType[],
+  numDays: number,
   dayStart: string,
   dayEnd: string,
   nightStart: string,
   nightEnd: string,
   year: string,
   monthDay: string,
-  date: string,
-  endDate: string,
 ) {
-  db.scan(res, Stats, condition, (data: Document[]) => {
-    if (data.length) {
-      res.write(JSON.stringify(data));
-      if (date === endDate) {
-        res.end();
-      }
-    } else {
+  Stats.get({ year, monthDay }, (err, data) => {
+    if (data) {
+      statsAcc.push(data.toJSON() as StatsType);
+      checkSend(res, statsAcc, numDays);
+    } else if (err || !data) {
       const conditionRidesDate = new Condition()
         .where('startTime')
         .between(dayStart, nightEnd)
@@ -83,22 +84,22 @@ function computeStats(
 
         dataDay.forEach((rideData: RideType) => {
           const driverName = `${rideData.driver?.firstName} ${rideData.driver?.lastName}`;
-          if (driversStat[driverName]) {
-            driversStat[driverName] += 1;
-          } else {
-            driversStat[driverName] = 1;
-          }
-          if (rideData.status === 'no_show') {
+          if (rideData.status === Status.NO_SHOW) {
             if (rideData.startTime <= dayEnd) {
               dayNoShowStat += 1;
             } else {
               nightNoShowStat += 1;
             }
-          } else if (rideData.status === 'completed') {
+          } else if (rideData.status === Status.COMPLETED) {
             if (rideData.startTime <= dayEnd) {
               dayCountStat += 1;
             } else {
               nightCountStat += 1;
+            }
+            if (driversStat[driverName]) {
+              driversStat[driverName] += 1;
+            } else {
+              driversStat[driverName] = 1;
             }
           }
         });
@@ -113,12 +114,13 @@ function computeStats(
           nightCancel: 0,
           drivers: driversStat,
         });
-        Stats.create(stats);
-        res.write(JSON.stringify(stats));
-        if (date === endDate) {
-          res.end();
-        }
+        Stats.create(stats).then((doc) => {
+          statsAcc.push(doc.toJSON() as StatsType);
+          checkSend(res, statsAcc, numDays);
+        });
       });
+    } else {
+      console.log('oh no');
     }
   });
 }


### PR DESCRIPTION
### Summary <!-- Required -->

This PR adds an endpoint that returns ride statistics for the days between (and including) `from` and `to`. It queries the Stats table for the data for these dates, or computes the data from the Rides table if there is no Stats entry for a date.

This PR also removes the "dailyTotal" field from the Stats schema.

### Test Plan <!-- Required -->

Call `GET / api/stats/:from/:to`

### Notes <!-- Optional -->

Ride cancellation is currently not implemented, so this returns 0 for dayCancel and nightCancel

