### PR TITLE
make blank schedule page

### DIFF
--- a/frontend/src/pages/Rider/Routes.tsx
+++ b/frontend/src/pages/Rider/Routes.tsx
@@ -6,6 +6,7 @@ import {
   Redirect,
 } from 'react-router-dom';
 import Sidebar from '../../components/Sidebar/Sidebar';
+import Schedule from './Schedule';
 import DateContext from '../../context/date';
 
 const Dashboard = () => {
@@ -19,7 +20,7 @@ const Dashboard = () => {
           <Switch>
             <Route
               path="/schedule"
-              component={() => null}
+              component={Schedule}
             />
             <Route
               path="/settings"

--- a/frontend/src/pages/Rider/Schedule.tsx
+++ b/frontend/src/pages/Rider/Schedule.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Toast from '../../components/ConfirmationToast/ConfirmationToast';
+import Notification from '../../components/Notification/Notification';
+
+const Schedule = () => (
+    <main id = "main">
+
+    </main>
+);
+export default Schedule;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This provides a blank page for the schedule for rider. This is done in a separate PR to prevent merge conflicts. The only element in the page right now is a <main> and the toast & notification are included to save time since both will be needed later, but neither are actually included. 
- [x] implemented Schedule page for rider
- [ ] fixed Y

### Test Plan <!-- Required -->

Went to localhost:3000/rider/schedule and found the main tag I included successfully and nothing crashes so I believe it works

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
