### PR TITLE
Fix adding admin

### DIFF
--- a/frontend/src/components/EmployeeModal/EmployeeModal.tsx
+++ b/frontend/src/components/EmployeeModal/EmployeeModal.tsx
@@ -223,12 +223,7 @@ const EmployeeModal = ({ existingEmployee }: EmployeeModalProps) => {
               phone={existingEmployee?.phone}
             />
             {selectedRole === 'admin' ? null : <StartDate />}
-            {
-              selectedRole === 'admin' ? null
-                : <WorkingHours
-                  existingAvailability={existingEmployee?.availability}
-                />
-            }
+            <WorkingHours existingAvailability={existingEmployee?.availability} hide={selectedRole === 'admin'}/>
             <RoleSelector
               selectedRole={selectedRole}
               setSelectedRole={setSelectedRole}

--- a/frontend/src/components/EmployeeModal/WorkingHours.tsx
+++ b/frontend/src/components/EmployeeModal/WorkingHours.tsx
@@ -10,12 +10,14 @@ type AvailabilityInputProps = {
   index: number;
   existingTimeRange?: string;
   existingDayArray?: string[];
+  hide: boolean;
 }
 
 const AvailabilityInput = ({
   index,
   existingTimeRange,
   existingDayArray,
+  hide
 }: AvailabilityInputProps) => {
   const {
     selectDay,
@@ -71,13 +73,13 @@ const AvailabilityInput = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // useEffect(() => {
-  //   // Register day selector as custom form input. 
-  //   //Not putting error message here since there is no default behavior to override
-  //   register(`${instance}.days`, { 
-  //     required: true, 
-  //     validate: () => {return days.length > 0}});
-  // }, [instance, register, days]);
+  useEffect(() => {
+    // Register day selector as custom form input. 
+    //Not putting error message here since there is no default behavior to override
+    register(`${instance}.days`, { 
+      required: !hide, 
+      validate: () => {return hide? true : days.length > 0}});
+  }, [instance, register, days, hide]);
 
   useEffect(() => {
     // When selected days changes, update days value
@@ -96,7 +98,7 @@ const AvailabilityInput = ({
           type='time'
           className={styles.timeInput}
           defaultValue={existingTime?.[0]}
-          ref={register({ required: true})}
+          ref={register({ required: !hide})}
         />
         {errors.availability && errors.availability[index] && 
           errors.availability[index].startTime &&  
@@ -111,10 +113,10 @@ const AvailabilityInput = ({
         className={styles.timeInput}
         defaultValue={existingTime?.[1]}
         ref={register({
-          required: true,
+          required: !hide,
           validate: (endTime) => {
             const startTime = getValues(`${instance}.startTime`);
-            return startTime < endTime;
+            return hide? true : startTime < endTime;
           },
         })}
       />
@@ -132,10 +134,6 @@ const AvailabilityInput = ({
               name={`${instance}.days`}
               type="button"
               value={label}
-              ref={register({
-                required: true,
-                validate: () => {return days.length > 0;}
-              })}
               className={cn(
                 styles.day,
                 { [styles.daySelected]: isDaySelectedByInstance(day, index) },
@@ -155,9 +153,10 @@ const AvailabilityInput = ({
 
 type WorkingHoursProps = {
   existingAvailability?: string[][];
+  hide: boolean;
 }
 
-const WorkingHours = ({ existingAvailability }: WorkingHoursProps) => {
+const WorkingHours = ({ existingAvailability, hide }: WorkingHoursProps) => {
   const [numAvailability, setNumAvailability] = useState(existingAvailability ? 0 : 1);
   const [availabilityArray, setAvailabilityArray] = useState<any[]>([]);
 
@@ -202,7 +201,7 @@ const WorkingHours = ({ existingAvailability }: WorkingHoursProps) => {
   }, []);
 
   return (
-    <div className={styles.workingHours}>
+    <div className={cn(styles.workingHours, { [styles.hidden]: hide })}>
       <p className={styles.workingHoursTitle}>Working Hours</p>
       <WeekProvider>
         {existingAvailability ? (
@@ -212,11 +211,12 @@ const WorkingHours = ({ existingAvailability }: WorkingHoursProps) => {
               index={index}
               existingTimeRange={timeRange}
               existingDayArray={dayArray}
+              hide={hide}
             />
           ))
         ) : (
           [...new Array(numAvailability)].map((_, index) => (
-            <AvailabilityInput key={index} index={index} />
+            <AvailabilityInput key={index} index={index} hide={hide} />
           ))
         )}
       </WeekProvider>

--- a/frontend/src/components/EmployeeModal/WorkingHours.tsx
+++ b/frontend/src/components/EmployeeModal/WorkingHours.tsx
@@ -71,13 +71,13 @@ const AvailabilityInput = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    // Register day selector as custom form input. 
-    //Not putting error message here since there is no default behavior to override
-    register(`${instance}.days`, { 
-      required: true, 
-      validate: () => {return days.length > 0}});
-  }, [instance, register, days]);
+  // useEffect(() => {
+  //   // Register day selector as custom form input. 
+  //   //Not putting error message here since there is no default behavior to override
+  //   register(`${instance}.days`, { 
+  //     required: true, 
+  //     validate: () => {return days.length > 0}});
+  // }, [instance, register, days]);
 
   useEffect(() => {
     // When selected days changes, update days value
@@ -132,6 +132,10 @@ const AvailabilityInput = ({
               name={`${instance}.days`}
               type="button"
               value={label}
+              ref={register({
+                required: true,
+                validate: () => {return days.length > 0;}
+              })}
               className={cn(
                 styles.day,
                 { [styles.daySelected]: isDaySelectedByInstance(day, index) },

--- a/frontend/src/components/EmployeeModal/employeemodal.module.css
+++ b/frontend/src/components/EmployeeModal/employeemodal.module.css
@@ -153,3 +153,6 @@
 .edit:hover {
   cursor: pointer;
 }
+.hidden{
+  display: none; 
+}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->
This is a (somewhat hacky) fix to fix adding an admin. This sets the display to none if the user selected an admin and validates the logic for the workingHours based on if the workingHours is hidden or not. 
- [] implemented X
- [x] fixed adding an admin

### Test Plan <!-- Required -->
Tested by adding Test A and test a successfully. 
Add Admin screen
<img width="960" alt="may_8_add_admin" src="https://user-images.githubusercontent.com/32024811/117554499-23c08f00-b026-11eb-8a3e-dfa9708992eb.png">
Add Driver screen
<img width="960" alt="may_8_add_driver" src="https://user-images.githubusercontent.com/32024811/117554501-24592580-b026-11eb-8b96-e301577924bb.png">


### Notes <!-- Optional -->
This is definitely a very hacky fix so may not recommend for future. 
That being said, it should be acceptable accessibility wise because display:none will remove it from accessibility focus or screen reader

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
