### PR TITLE
Cancel rides

### DIFF
--- a/server/models/ride.ts
+++ b/server/models/ride.ts
@@ -19,6 +19,7 @@ export enum Status {
   PICKED_UP = 'picked_up',
   COMPLETED = 'completed',
   NO_SHOW = 'no_show',
+  CANCELLED = 'cancelled',
 }
 
 export type RideLocation = {

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -26,7 +26,7 @@ router.get('/download', (req, res) => {
     .between(dateStart, dateEnd)
 
   const callback = (value: any) => {
-    const dataToExport =
+    const dataToExport = 
     value
       .sort((a: any, b: any) => {
         return moment(a.startTime).diff(moment(b.startTime));
@@ -214,24 +214,24 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
 router.delete('/:id', validateUser('User'), (req, res) => {
   const { params: { id } } = req;
   db.getById(res, Ride, id, tableName, (ride) => {
-    const { recurring, edits, status } = ride;
-    if (status === Type.ACTIVE) {
-      const operation = { $SET: { status: Status.CANCELLED } };
-      db.update(res, Ride, { id }, operation, tableName);
-    } else {
-      const deleteRide = () => {
+    const { recurring, edits, type } = ride;
+    const deleteRide = () => {
+      if (type === Type.ACTIVE) {
+        const operation = { $SET: { status: Status.CANCELLED } };
+        db.update(res, Ride, { id }, operation, tableName);
+      } else {
         Ride.delete(id)
           .then(() => res.send({ id }))
           .catch((err) => res.status(500).send({ err: err.message }));
-      };
-      if (recurring && edits.length) {
-        const ids = createKeys('id', edits);
-        Ride.batchDelete(ids)
-          .then(deleteRide)
-          .catch((err) => res.status(500).send({ err: err.message }));
-      } else {
-        deleteRide();
       }
+    };
+    if (recurring && edits.length) {
+      const ids = createKeys('id', edits);
+      Ride.batchDelete(ids)
+        .then(deleteRide)
+        .catch((err) => res.status(500).send({ err: err.message }));
+    } else {
+      deleteRide();
     }
   });
 });

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -104,8 +104,10 @@ function computeStats(
       db.scan(res, Ride, conditionRidesDate, (dataDay: RideType[]) => {
         let dayCountStat = 0;
         let dayNoShowStat = 0;
+        let dayCancelStat = 0;
         let nightCountStat = 0;
         let nightNoShowStat = 0;
+        let nightCancelStat = 0;
         const driversStat: { [name: string]: number } = {};
 
         dataDay.forEach((rideData: RideType) => {
@@ -127,6 +129,12 @@ function computeStats(
             } else {
               driversStat[driverName] = 1;
             }
+          } else if (rideData.status === Status.CANCELLED) {
+            if (rideData.startTime <= dayEnd) {
+              dayCancelStat += 1;
+            } else {
+              nightCancelStat += 1;
+            }
           }
         });
         const stats = new Stats({
@@ -134,10 +142,10 @@ function computeStats(
           monthDay,
           dayCount: dayCountStat,
           dayNoShow: dayNoShowStat,
-          dayCancel: 0,
+          dayCancel: dayCancelStat,
           nightCount: nightCountStat,
           nightNoShow: nightNoShowStat,
-          nightCancel: 0,
+          nightCancel: nightCancelStat,
           drivers: driversStat,
         });
         Stats.create(stats).then((doc) => {


### PR DESCRIPTION
### Summary <!-- Required -->

This PR implements ride cancellation by adding a Ride Status enum value "cancelled" and changing the `DELETE api/rides/:id` endpoint to setting "active" rides' statuses to "cancelled" instead of deleting them.

This PR also updates the `GET api/stats` endpoint to count the number of cancelled day and night rides.

### Test Plan <!-- Required -->

Call `DELETE api/rides/:id` on an active vs non-active rides
Call `GET api/stats` to get the cancelled ride counts
