### PR TITLE
Add change type to notification body

### DIFF
--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -11,6 +11,7 @@ import { validateUser, daysUntilWeekday } from '../util';
 import { DriverType } from '../models/driver';
 import { RiderType } from '../models/rider';
 import { notifyEdit } from '../util/notification';
+import { Change } from '../util/types';
 
 
 const router = express.Router();
@@ -267,7 +268,7 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
         // create replace edit and add replaceId to edits field
         db.create(res, replaceRide, (editRide) => {
           db.update(res, Ride, { id }, addEditOperation, tableName, () => {
-            notifyEdit(editRide, change, userType, userId)
+            notifyEdit(editRide, change, userType, userId, Change.REPEATING_EDITED)
               .then(() => res.send(editRide)).catch(() => res.send(editRide));
             // res.send(editRide);
           });
@@ -318,7 +319,7 @@ router.delete('/:id', validateUser('User'), (req, res) => {
   db.getById(res, Ride, id, tableName, (ride) => {
     const { recurring, type } = ride;
     if (type === Type.ACTIVE) {
-      const operation = { $SET: { status: Status.CANCELLED } };
+      const operation = { status: Status.CANCELLED };
       db.update(res, Ride, { id }, operation, tableName, (doc) => {
         const deletedRide = JSON.parse(JSON.stringify(doc.toJSON()));
         const { userType } = res.locals.user;

--- a/server/util/notification.ts
+++ b/server/util/notification.ts
@@ -8,7 +8,8 @@ import {
   UserType,
   PlatformType,
 } from '../models/subscription';
-import { RideType } from '../models/ride';
+import { RideType, Status, Type } from '../models/ride';
+import { Change } from './types';
 
 AWS.config.update({ ...config, region: 'us-east-1' });
 const sns = new AWS.SNS();
@@ -168,19 +169,37 @@ export const sendToUsers = (
   });
 });
 
+const getChangeType = (
+  change: Partial<RideType>,
+): Change | Status => {
+  const { status, late, type, driver } = change;
+  if (status) {
+    return status;
+  }
+  if (late) {
+    return Change.LATE;
+  }
+  if (type === Type.ACTIVE && driver) {
+    return Change.SCHEDULED;
+  }
+  return Change.EDITED;
+};
+
 export const notifyEdit = (
   updatedRide: RideType,
-  change: any,
+  body: Partial<RideType>,
   userType: UserType,
   userId: string,
+  change?: Change,
 ) => new Promise((resolve, reject) => {
   const riderId = updatedRide.rider.id;
   const hasDriver = updatedRide.driver;
   const driverId = hasDriver ? updatedRide.driver!.id : '';
+  const changeType = change || getChangeType(body);
 
   const info = JSON.stringify({
     ride: updatedRide,
-    change,
+    changeType,
     changedBy: { userType, userId },
   });
 

--- a/server/util/types.ts
+++ b/server/util/types.ts
@@ -5,3 +5,10 @@ export type JWTPayload = {
   userType: UserType;
   iat: string;
 }
+
+export enum Change {
+  LATE = 'late',
+  SCHEDULED = 'scheduled',
+  EDITED = 'edited',
+  REPEATING_EDITED = 'repeating_edited',
+}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This PR adds change types to the notification body, so the client can determine what kind of change was made to a ride. The possible values for `changeType` are:
```
{
  NOT_STARTED = 'not_started',
  ON_THE_WAY = 'on_the_way',
  ARRIVED = 'arrived',
  PICKED_UP = 'picked_up',
  COMPLETED = 'completed',
  NO_SHOW = 'no_show',
  CANCELLED = 'cancelled',
  LATE = 'late',
  SCHEDULED = 'scheduled',
  EDITED = 'edited',
  REPEATING_EDITED = 'repeating_edited',
}
```

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Run the server locally, log the value of `info`, and edit a ride.