### PR TITLE
Revert mobile notifications back from GCM change

### DIFF
--- a/server/util/notification.ts
+++ b/server/util/notification.ts
@@ -76,24 +76,11 @@ const sendMsg = (sub: SubscriptionType, msg: string) => {
         });
     });
   }
-  // mobile notification
 
-  const snsMsg = {
-    GCM: {
-      notification: {
-        body: msg,
-        click_action: 'FLUTTER_NOTIFICATION_CLICK',
-      },
-      data: {
-        additional: msg,
-      },
-    },
-  };
 
   const snsParams = {
-    Message: JSON.stringify(snsMsg),
+    Message: msg,
     TargetArn: sub.endpoint,
-    MessageStructure: 'json',
   };
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Summary <!-- Required -->

Reverted mobile notifications from GCM change to what it was previously

### Test Plan <!-- Required -->

Tested foreground and background notifications on Android device

### Notes <!-- Optional -->

Will need to test with iOS in the future
