### PR TITLE
Set default timezone for moment

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -16,6 +16,7 @@ import stats from './router/stats';
 import initSchedule from './util/repeatingRide';
 import notification from './router/notification';
 import initDynamoose from './util/dynamoose';
+import moment from "moment-timezone"
 
 const port = Number(process.env.PORT) || 3001;
 
@@ -54,6 +55,9 @@ app.use(express.static(path.join(__dirname, frontendBuild)));
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, frontendBuild, 'index.html'));
 });
+
+// Set default timezone for moment
+moment.tz.setDefault("America/New_York");
 
 initSchedule();
 

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -51,8 +51,8 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
     params: { id, startTime, endTime },
   } = req;
 
-  const reqStart = moment.tz(startTime, 'America/New_York');
-  const reqEnd = moment.tz(endTime, 'America/New_York');
+  const reqStart = moment.tz(startTime);
+  const reqEnd = moment.tz(endTime);
 
   if (reqStart.date() !== reqEnd.date()) {
     res.status(400).send({ err: 'startTime and endTime dates must be equal' });
@@ -65,8 +65,8 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
     res.status(400).send({ err: 'startTime must precede endTime' });
   }
 
-  const reqStartDay = moment.tz(startTime, 'America/New_York').day();
-  const reqEndDay = moment.tz(endTime, 'America/New_York').day();
+  const reqStartDay = moment.tz(startTime).day();
+  const reqEndDay = moment.tz(endTime).day();
 
   let available = false;
 
@@ -82,7 +82,7 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
     })();
 
     const availStartTime = moment
-      .tz(availStart as string, 'HH:mm', 'America/New_York')
+      .tz(availStart as string, 'HH:mm')
       .format('HH:mm');
 
     if (availStart != null && availStartTime <= reqStartTime) {
@@ -96,7 +96,7 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
       })();
 
       const availEndTime = moment
-        .tz(availEnd as string, 'HH:mm', 'America/New_York')
+        .tz(availEnd as string, 'HH:mm')
         .format('HH:mm');
 
       if (availEnd != null && availEndTime >= reqEndTime) {

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -19,10 +19,10 @@ const tableName = 'Rides';
 
 router.get('/download', (req, res) => {
   const dateStart = moment
-    .tz(req.query.date as string, 'America/New_York')
+    .tz(req.query.date as string)
     .toISOString();
   const dateEnd = moment
-    .tz(req.query.date as string, 'America/New_York')
+    .tz(req.query.date as string)
     .endOf('day')
     .toISOString();
   const condition = new Condition()
@@ -36,8 +36,8 @@ router.get('/download', (req, res) => {
     const dataToExport = value
       .sort((a: any, b: any) => moment(a.startTime).diff(moment(b.startTime)))
       .map((doc: any) => {
-        const start = moment.tz(doc.startTime, 'America/New_York');
-        const end = moment.tz(doc.endTime, 'America/New_York');
+        const start = moment.tz(doc.startTime);
+        const end = moment.tz(doc.endTime);
         const fullName = (user: RiderType | DriverType) =>
           `${user.firstName} ${user.lastName.substring(0, 1)}.`;
         return {
@@ -63,7 +63,7 @@ router.get('/repeating', validateUser('User'), (req, res) => {
   const {
     query: { rider },
   } = req;
-  const now = moment.tz('America/New_York').format('YYYY-MM-DD');
+  const now = moment.tz().format('YYYY-MM-DD');
   let condition = new Condition('recurring')
     .eq(true)
     .where('endDate')
@@ -105,10 +105,10 @@ router.get('/', validateUser('User'), (req, res) => {
   }
   if (date) {
     const dateStart = moment
-      .tz(date as string, 'America/New_York')
+      .tz(date as string)
       .toISOString();
     const dateEnd = moment
-      .tz(date as string, 'America/New_York')
+      .tz(date as string)
       .endOf('day')
       .toISOString();
     condition = condition.where('startTime').between(dateStart, dateEnd);
@@ -239,20 +239,20 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
 
   db.getById(res, Ride, id, tableName, (masterRide: RideType) => {
     const masterStartDate = moment
-      .tz(masterRide.startTime, 'America/New_York')
+      .tz(masterRide.startTime)
       .format('YYYY-MM-DD');
     const origStartTimeOnly = moment
-      .tz(masterRide.startTime, 'America/New_York')
+      .tz(masterRide.startTime)
       .format('HH:mm:ss');
     const origStartTime = moment
-      .tz(`${origDate}T${origStartTimeOnly}`, 'America/New_York')
+      .tz(`${origDate}T${origStartTimeOnly}`)
       .toISOString();
 
     const origEndTimeOnly = moment
-      .tz(masterRide.endTime, 'America/New_York')
+      .tz(masterRide.endTime)
       .format('HH:mm:ss');
     const origEndTime = moment
-      .tz(`${origDate}T${origEndTimeOnly}`, 'America/New_York')
+      .tz(`${origDate}T${origEndTimeOnly}`)
       .toISOString();
 
     const handleEdit = (change: any) => (ride: RideType) => {
@@ -323,8 +323,8 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
       );
     } else if (origDate === masterStartDate) {
       // move master repeating ride start and end to next occurrence
-      const momentStart = moment.tz(masterRide.startTime, 'America/New_York');
-      const momentEnd = moment.tz(masterRide.endTime, 'America/New_York');
+      const momentStart = moment.tz(masterRide.startTime);
+      const momentEnd = moment.tz(masterRide.endTime);
       const nextRideDays = masterRide.recurringDays!.reduce(
         (acc, curr) => Math.min(acc, daysUntilWeekday(momentStart, curr)),
         8

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -122,8 +122,8 @@ router.get('/:id/currentride', validateUser('Rider'), (req, res) => {
     params: { id },
   } = req;
   db.getById(res, Rider, id, tableName, () => {
-    const now = moment.tz('America/New_York').toISOString();
-    const end = moment.tz('America/New_York').add(30, 'minutes').toISOString();
+    const now = moment.tz().toISOString();
+    const end = moment.tz().add(30, 'minutes').toISOString();
     const isRider = new Condition('rider').eq(id);
     const isActive = new Condition('type').eq(Type.ACTIVE);
     const isSoon = new Condition('startTime').between(now, end);

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -16,7 +16,7 @@ router.get('/download', validateUser('Admin'), (req, res) => {
   const {
     query: { from, to },
   } = req;
-  let date = moment.tz(from, 'America/New_York').format('YYYY-MM-DD');
+  let date = moment.tz(from as string).format('YYYY-MM-DD');
   const dates = [date];
   if (to) {
     date = moment
@@ -74,7 +74,7 @@ router.get('/', validateUser('Admin'), (req, res) => {
   const toMatch = to ? (to as string).match(regexp) : true;
 
   if (fromMatch && toMatch) {
-    let date = moment.tz(from, 'America/New_York').format('YYYY-MM-DD');
+    let date = moment.tz(from as string).format('YYYY-MM-DD');
     const dates = [date];
     if (to) {
       date = moment

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -20,13 +20,13 @@ router.get('/download', validateUser('Admin'), (req, res) => {
   const dates = [date];
   if (to) {
     date = moment
-      .tz(date, 'America/New_York')
+      .tz(date)
       .add(1, 'days')
       .format('YYYY-MM-DD');
     while (date <= to) {
       dates.push(date);
       date = moment
-        .tz(date, 'America/New_York')
+        .tz(date)
         .add(1, 'days')
         .format('YYYY-MM-DD');
     }
@@ -46,10 +46,10 @@ router.put('/', validateUser('Admin'), (req, res) => {
 
   Object.keys(dates).forEach((date: string) => {
     const year = moment
-      .tz(date as string, 'MM/DD/YYYY', 'America/New_York')
+      .tz(date as string, 'MM/DD/YYYY')
       .format('YYYY');
     const monthDay = moment
-      .tz(date as string, 'MM/DD/YYYY', 'America/New_York')
+      .tz(date as string, 'MM/DD/YYYY')
       .format('MMDD');
     const operation = { $SET: dates[date] };
     const key = { year, monthDay };
@@ -78,13 +78,13 @@ router.get('/', validateUser('Admin'), (req, res) => {
     const dates = [date];
     if (to) {
       date = moment
-        .tz(date, 'America/New_York')
+        .tz(date)
         .add(1, 'days')
         .format('YYYY-MM-DD');
       while (date <= to) {
         dates.push(date);
         date = moment
-          .tz(date, 'America/New_York')
+          .tz(date)
           .add(1, 'days')
           .format('YYYY-MM-DD');
       }
@@ -100,23 +100,23 @@ function statsFromDates(dates: string[], res: Response, download: boolean) {
 
   dates.forEach((currDate) => {
     const year = moment
-      .tz(currDate, 'YYYY-MM-DD', 'America/New_York')
+      .tz(currDate, 'YYYY-MM-DD')
       .format('YYYY');
     const monthDay = moment
-      .tz(currDate, 'YYYY-MM-DD', 'America/New_York')
+      .tz(currDate, 'YYYY-MM-DD')
       .format('MMDD');
 
-    const dateMoment = moment.tz(currDate, 'America/New_York');
+    const dateMoment = moment.tz(currDate);
     // day = 12am to 5:00pm
     const dayStart = dateMoment.toISOString();
     const dayEnd = dateMoment.add(17, 'hours').toISOString();
     // night = 5:01pm to 11:59:59pm
     const nightStart = moment
-      .tz(dayEnd, 'America/New_York')
+      .tz(dayEnd)
       .add(1, 'seconds')
       .toISOString();
     const nightEnd = moment
-      .tz(currDate as string, 'America/New_York')
+      .tz(currDate as string)
       .endOf('day')
       .toISOString();
 

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -115,10 +115,10 @@ export const daysUntilWeekday = (
 };
 
 export const timeToMDY = (time: string) =>
-  moment.tz(time, 'America/New_York').format('l');
+  moment.tz(time).format('l');
 
 export const timeTo12Hr = (time: string) =>
-  moment.tz(time, 'America/New_York').format('LT');
+  moment.tz(time).format('LT');
 
 export const getRideLocation = (value: ValueType) => {
   if (typeof value === 'string') {


### PR DESCRIPTION
### Summary <!-- Required -->

Set a default timezone for moment using moment.tz.setDefault()

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
I tested it on my laptop by switching to the London timezone and making sure that moment still outputs in EST.
By inserting console.logs in app.ts.

### Notes <!-- Optional -->

According to moment's documentation, the default timezone should be set universally so it should work across different ts files. However, I didn't find a way to test its output in other files e.g. stats.ts. It works fine in app.ts.

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
