### PR TITLE
Set default timezone for moment

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -6,7 +6,7 @@ import cors from 'cors';
 
 // Set default timezone for moment
 import moment from 'moment-timezone';
-moment.tz.setDefault("America/New_York");
+moment.tz.setDefault('America/New_York');
 
 import config from './config';
 import rider from './router/rider';

--- a/server/app.ts
+++ b/server/app.ts
@@ -3,6 +3,11 @@ import express from 'express';
 import dynamoose from 'dynamoose';
 import path from 'path';
 import cors from 'cors';
+
+// Set default timezone for moment
+import moment from 'moment-timezone';
+moment.tz.setDefault("America/New_York");
+
 import config from './config';
 import rider from './router/rider';
 import driver from './router/driver';

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -51,8 +51,8 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
     params: { id, startTime, endTime },
   } = req;
 
-  const reqStart = moment.tz(startTime, 'America/New_York');
-  const reqEnd = moment.tz(endTime, 'America/New_York');
+  const reqStart = moment(startTime);
+  const reqEnd = moment(endTime);
 
   if (reqStart.date() !== reqEnd.date()) {
     res.status(400).send({ err: 'startTime and endTime dates must be equal' });
@@ -65,8 +65,8 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
     res.status(400).send({ err: 'startTime must precede endTime' });
   }
 
-  const reqStartDay = moment.tz(startTime, 'America/New_York').day();
-  const reqEndDay = moment.tz(endTime, 'America/New_York').day();
+  const reqStartDay = moment(startTime).day();
+  const reqEndDay = moment(endTime).day();
 
   let available = false;
 
@@ -82,7 +82,7 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
     })();
 
     const availStartTime = moment
-      .tz(availStart as string, 'HH:mm', 'America/New_York')
+      (availStart as string, 'HH:mm')
       .format('HH:mm');
 
     if (availStart != null && availStartTime <= reqStartTime) {
@@ -96,7 +96,7 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
       })();
 
       const availEndTime = moment
-        .tz(availEnd as string, 'HH:mm', 'America/New_York')
+        (availEnd as string, 'HH:mm')
         .format('HH:mm');
 
       if (availEnd != null && availEndTime >= reqEndTime) {

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -81,9 +81,9 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
       return null;
     })();
 
-    const availStartTime = moment
-      (availStart as string, 'HH:mm')
-      .format('HH:mm');
+    const availStartTime = moment(availStart as string, 'HH:mm').format(
+      'HH:mm'
+    );
 
     if (availStart != null && availStartTime <= reqStartTime) {
       const availEnd = (() => {
@@ -95,9 +95,7 @@ router.get('/:id/:startTime/:endTime', (req, res) => {
         return null;
       })();
 
-      const availEndTime = moment
-        (availEnd as string, 'HH:mm')
-        .format('HH:mm');
+      const availEndTime = moment(availEnd as string, 'HH:mm').format('HH:mm');
 
       if (availEnd != null && availEndTime >= reqEndTime) {
         available = true;

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -18,11 +18,8 @@ const router = express.Router();
 const tableName = 'Rides';
 
 router.get('/download', (req, res) => {
-  const dateStart = moment
-    (req.query.date as string)
-    .toISOString();
-  const dateEnd = moment
-    (req.query.date as string)
+  const dateStart = moment(req.query.date as string).toISOString();
+  const dateEnd = moment(req.query.date as string)
     .endOf('day')
     .toISOString();
   const condition = new Condition()
@@ -104,11 +101,8 @@ router.get('/', validateUser('User'), (req, res) => {
     condition = condition.where('driver').eq(driver);
   }
   if (date) {
-    const dateStart = moment
-      (date as string)
-      .toISOString();
-    const dateEnd = moment
-      (date as string)
+    const dateStart = moment(date as string).toISOString();
+    const dateEnd = moment(date as string)
       .endOf('day')
       .toISOString();
     condition = condition.where('startTime').between(dateStart, dateEnd);
@@ -238,22 +232,14 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
   } = req;
 
   db.getById(res, Ride, id, tableName, (masterRide: RideType) => {
-    const masterStartDate = moment
-      (masterRide.startTime)
-      .format('YYYY-MM-DD');
-    const origStartTimeOnly = moment
-      (masterRide.startTime)
-      .format('HH:mm:ss');
-    const origStartTime = moment
-      (`${origDate}T${origStartTimeOnly}`)
-      .toISOString();
+    const masterStartDate = moment(masterRide.startTime).format('YYYY-MM-DD');
+    const origStartTimeOnly = moment(masterRide.startTime).format('HH:mm:ss');
+    const origStartTime = moment(
+      `${origDate}T${origStartTimeOnly}`
+    ).toISOString();
 
-    const origEndTimeOnly = moment
-      (masterRide.endTime)
-      .format('HH:mm:ss');
-    const origEndTime = moment
-      (`${origDate}T${origEndTimeOnly}`)
-      .toISOString();
+    const origEndTimeOnly = moment(masterRide.endTime).format('HH:mm:ss');
+    const origEndTime = moment(`${origDate}T${origEndTimeOnly}`).toISOString();
 
     const handleEdit = (change: any) => (ride: RideType) => {
       const { userType } = res.locals.user;

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -19,10 +19,10 @@ const tableName = 'Rides';
 
 router.get('/download', (req, res) => {
   const dateStart = moment
-    .tz(req.query.date as string, 'America/New_York')
+    (req.query.date as string)
     .toISOString();
   const dateEnd = moment
-    .tz(req.query.date as string, 'America/New_York')
+    (req.query.date as string)
     .endOf('day')
     .toISOString();
   const condition = new Condition()
@@ -36,8 +36,8 @@ router.get('/download', (req, res) => {
     const dataToExport = value
       .sort((a: any, b: any) => moment(a.startTime).diff(moment(b.startTime)))
       .map((doc: any) => {
-        const start = moment.tz(doc.startTime, 'America/New_York');
-        const end = moment.tz(doc.endTime, 'America/New_York');
+        const start = moment(doc.startTime);
+        const end = moment(doc.endTime);
         const fullName = (user: RiderType | DriverType) =>
           `${user.firstName} ${user.lastName.substring(0, 1)}.`;
         return {
@@ -63,7 +63,7 @@ router.get('/repeating', validateUser('User'), (req, res) => {
   const {
     query: { rider },
   } = req;
-  const now = moment.tz('America/New_York').format('YYYY-MM-DD');
+  const now = moment().format('YYYY-MM-DD');
   let condition = new Condition('recurring')
     .eq(true)
     .where('endDate')
@@ -105,10 +105,10 @@ router.get('/', validateUser('User'), (req, res) => {
   }
   if (date) {
     const dateStart = moment
-      .tz(date as string, 'America/New_York')
+      (date as string)
       .toISOString();
     const dateEnd = moment
-      .tz(date as string, 'America/New_York')
+      (date as string)
       .endOf('day')
       .toISOString();
     condition = condition.where('startTime').between(dateStart, dateEnd);
@@ -239,20 +239,20 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
 
   db.getById(res, Ride, id, tableName, (masterRide: RideType) => {
     const masterStartDate = moment
-      .tz(masterRide.startTime, 'America/New_York')
+      (masterRide.startTime)
       .format('YYYY-MM-DD');
     const origStartTimeOnly = moment
-      .tz(masterRide.startTime, 'America/New_York')
+      (masterRide.startTime)
       .format('HH:mm:ss');
     const origStartTime = moment
-      .tz(`${origDate}T${origStartTimeOnly}`, 'America/New_York')
+      (`${origDate}T${origStartTimeOnly}`)
       .toISOString();
 
     const origEndTimeOnly = moment
-      .tz(masterRide.endTime, 'America/New_York')
+      (masterRide.endTime)
       .format('HH:mm:ss');
     const origEndTime = moment
-      .tz(`${origDate}T${origEndTimeOnly}`, 'America/New_York')
+      (`${origDate}T${origEndTimeOnly}`)
       .toISOString();
 
     const handleEdit = (change: any) => (ride: RideType) => {
@@ -323,8 +323,8 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
       );
     } else if (origDate === masterStartDate) {
       // move master repeating ride start and end to next occurrence
-      const momentStart = moment.tz(masterRide.startTime, 'America/New_York');
-      const momentEnd = moment.tz(masterRide.endTime, 'America/New_York');
+      const momentStart = moment(masterRide.startTime);
+      const momentEnd = moment(masterRide.endTime);
       const nextRideDays = masterRide.recurringDays!.reduce(
         (acc, curr) => Math.min(acc, daysUntilWeekday(momentStart, curr)),
         8

--- a/server/router/rider.ts
+++ b/server/router/rider.ts
@@ -122,8 +122,8 @@ router.get('/:id/currentride', validateUser('Rider'), (req, res) => {
     params: { id },
   } = req;
   db.getById(res, Rider, id, tableName, () => {
-    const now = moment.tz('America/New_York').toISOString();
-    const end = moment.tz('America/New_York').add(30, 'minutes').toISOString();
+    const now = moment().toISOString();
+    const end = moment().add(30, 'minutes').toISOString();
     const isRider = new Condition('rider').eq(id);
     const isActive = new Condition('type').eq(Type.ACTIVE);
     const isSoon = new Condition('startTime').between(now, end);

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -16,17 +16,17 @@ router.get('/download', validateUser('Admin'), (req, res) => {
   const {
     query: { from, to },
   } = req;
-  let date = moment.tz(from, 'America/New_York').format('YYYY-MM-DD');
+  let date = moment(from as string).format('YYYY-MM-DD');
   const dates = [date];
   if (to) {
     date = moment
-      .tz(date, 'America/New_York')
+      (date)
       .add(1, 'days')
       .format('YYYY-MM-DD');
     while (date <= to) {
       dates.push(date);
       date = moment
-        .tz(date, 'America/New_York')
+        (date)
         .add(1, 'days')
         .format('YYYY-MM-DD');
     }
@@ -46,10 +46,10 @@ router.put('/', validateUser('Admin'), (req, res) => {
 
   Object.keys(dates).forEach((date: string) => {
     const year = moment
-      .tz(date as string, 'MM/DD/YYYY', 'America/New_York')
+      (date as string, 'MM/DD/YYYY')
       .format('YYYY');
     const monthDay = moment
-      .tz(date as string, 'MM/DD/YYYY', 'America/New_York')
+      (date as string, 'MM/DD/YYYY')
       .format('MMDD');
     const operation = { $SET: dates[date] };
     const key = { year, monthDay };
@@ -74,17 +74,17 @@ router.get('/', validateUser('Admin'), (req, res) => {
   const toMatch = to ? (to as string).match(regexp) : true;
 
   if (fromMatch && toMatch) {
-    let date = moment.tz(from, 'America/New_York').format('YYYY-MM-DD');
+    let date = moment(from as string).format('YYYY-MM-DD');
     const dates = [date];
     if (to) {
       date = moment
-        .tz(date, 'America/New_York')
+        (date)
         .add(1, 'days')
         .format('YYYY-MM-DD');
       while (date <= to) {
         dates.push(date);
         date = moment
-          .tz(date, 'America/New_York')
+          (date)
           .add(1, 'days')
           .format('YYYY-MM-DD');
       }
@@ -100,23 +100,23 @@ function statsFromDates(dates: string[], res: Response, download: boolean) {
 
   dates.forEach((currDate) => {
     const year = moment
-      .tz(currDate, 'YYYY-MM-DD', 'America/New_York')
+      (currDate, 'YYYY-MM-DD')
       .format('YYYY');
     const monthDay = moment
-      .tz(currDate, 'YYYY-MM-DD', 'America/New_York')
+      (currDate, 'YYYY-MM-DD')
       .format('MMDD');
 
-    const dateMoment = moment.tz(currDate, 'America/New_York');
+    const dateMoment = moment(currDate);
     // day = 12am to 5:00pm
     const dayStart = dateMoment.toISOString();
     const dayEnd = dateMoment.add(17, 'hours').toISOString();
     // night = 5:01pm to 11:59:59pm
     const nightStart = moment
-      .tz(dayEnd, 'America/New_York')
+      (dayEnd)
       .add(1, 'seconds')
       .toISOString();
     const nightEnd = moment
-      .tz(currDate as string, 'America/New_York')
+      (currDate as string)
       .endOf('day')
       .toISOString();
 

--- a/server/router/stats.ts
+++ b/server/router/stats.ts
@@ -19,16 +19,10 @@ router.get('/download', validateUser('Admin'), (req, res) => {
   let date = moment(from as string).format('YYYY-MM-DD');
   const dates = [date];
   if (to) {
-    date = moment
-      (date)
-      .add(1, 'days')
-      .format('YYYY-MM-DD');
+    date = moment(date).add(1, 'days').format('YYYY-MM-DD');
     while (date <= to) {
       dates.push(date);
-      date = moment
-        (date)
-        .add(1, 'days')
-        .format('YYYY-MM-DD');
+      date = moment(date).add(1, 'days').format('YYYY-MM-DD');
     }
   }
 
@@ -45,12 +39,8 @@ router.put('/', validateUser('Admin'), (req, res) => {
   const statsAcc: StatsType[] = [];
 
   Object.keys(dates).forEach((date: string) => {
-    const year = moment
-      (date as string, 'MM/DD/YYYY')
-      .format('YYYY');
-    const monthDay = moment
-      (date as string, 'MM/DD/YYYY')
-      .format('MMDD');
+    const year = moment(date as string, 'MM/DD/YYYY').format('YYYY');
+    const monthDay = moment(date as string, 'MM/DD/YYYY').format('MMDD');
     const operation = { $SET: dates[date] };
     const key = { year, monthDay };
 
@@ -77,16 +67,10 @@ router.get('/', validateUser('Admin'), (req, res) => {
     let date = moment(from as string).format('YYYY-MM-DD');
     const dates = [date];
     if (to) {
-      date = moment
-        (date)
-        .add(1, 'days')
-        .format('YYYY-MM-DD');
+      date = moment(date).add(1, 'days').format('YYYY-MM-DD');
       while (date <= to) {
         dates.push(date);
-        date = moment
-          (date)
-          .add(1, 'days')
-          .format('YYYY-MM-DD');
+        date = moment(date).add(1, 'days').format('YYYY-MM-DD');
       }
     }
     statsFromDates(dates, res, false);
@@ -99,24 +83,16 @@ function statsFromDates(dates: string[], res: Response, download: boolean) {
   const statsAcc: StatsType[] = [];
 
   dates.forEach((currDate) => {
-    const year = moment
-      (currDate, 'YYYY-MM-DD')
-      .format('YYYY');
-    const monthDay = moment
-      (currDate, 'YYYY-MM-DD')
-      .format('MMDD');
+    const year = moment(currDate, 'YYYY-MM-DD').format('YYYY');
+    const monthDay = moment(currDate, 'YYYY-MM-DD').format('MMDD');
 
     const dateMoment = moment(currDate);
     // day = 12am to 5:00pm
     const dayStart = dateMoment.toISOString();
     const dayEnd = dateMoment.add(17, 'hours').toISOString();
     // night = 5:01pm to 11:59:59pm
-    const nightStart = moment
-      (dayEnd)
-      .add(1, 'seconds')
-      .toISOString();
-    const nightEnd = moment
-      (currDate as string)
+    const nightStart = moment(dayEnd).add(1, 'seconds').toISOString();
+    const nightEnd = moment(currDate as string)
       .endOf('day')
       .toISOString();
 

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -114,11 +114,9 @@ export const daysUntilWeekday = (
   return days || 7;
 };
 
-export const timeToMDY = (time: string) =>
-  moment(time).format('l');
+export const timeToMDY = (time: string) => moment(time).format('l');
 
-export const timeTo12Hr = (time: string) =>
-  moment(time).format('LT');
+export const timeTo12Hr = (time: string) => moment(time).format('LT');
 
 export const getRideLocation = (value: ValueType) => {
   if (typeof value === 'string') {

--- a/server/util/index.ts
+++ b/server/util/index.ts
@@ -115,10 +115,10 @@ export const daysUntilWeekday = (
 };
 
 export const timeToMDY = (time: string) =>
-  moment.tz(time, 'America/New_York').format('l');
+  moment(time).format('l');
 
 export const timeTo12Hr = (time: string) =>
-  moment.tz(time, 'America/New_York').format('LT');
+  moment(time).format('LT');
 
 export const getRideLocation = (value: ValueType) => {
   if (typeof value === 'string') {


### PR DESCRIPTION
### Summary <!-- Required -->

Set default timezone for moment using moment.tz.setDefault().

All previous usages of moment.tz() are replaced with moment().

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

### Test Plan <!-- Required -->

I switched my own laptop's local timezone to London and console logged the result of moment().format(). It turns out to be converted to EST, which is ideal.

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

It seems that I have to set the default timezone in app.ts before importing other files (riders, stats, etc) so that the default timezone works in those files as well.

<!--- List any important or subtle points, future considerations, or other items of note. -->

<!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
