### PR TITLE
fl334/available drivers

### DIFF
--- a/server/models/driver.ts
+++ b/server/models/driver.ts
@@ -7,7 +7,7 @@ type Availability = {
   endTime: string;
 };
 
-type AvailabilityType = {
+export type AvailabilityType = {
   Mon?: Availability;
   Tue?: Availability;
   Wed?: Availability;

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -46,10 +46,7 @@ router.get('/available', validateUser('User'), (req, res) => {
         return false;
       }
 
-      return (
-        availEnd >= reqEndTime &&
-        availStart <= reqStartTime
-      );
+      return availEnd >= reqEndTime && availStart <= reqStartTime;
     });
 
     res.send({ data: drivers });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -14,6 +14,7 @@ const tableName = 'Drivers';
 
 // Get a driver by id in Drivers table
 router.get('/:id', validateUser('User'), (req, res) => {
+    console.log("triggered wrong")
   const {
     params: { id },
   } = req;
@@ -45,7 +46,8 @@ router.get('/:id/profile', validateUser('User'), (req, res) => {
 });
 
 // Get all available drivers at a given time
-router.get('/available', validateUser('Admin'), (req, res) => {
+router.get('/test/available', validateUser('Admin'), (req, res) => {
+  console.log("triggered")
   const { date, reqStartTime, reqEndTime } = req.query;
   const startTime = moment(reqStartTime as string, 'HH:mm');
   const endTime = moment(reqEndTime as string, 'HH:mm');
@@ -73,12 +75,13 @@ router.get('/available', validateUser('Admin'), (req, res) => {
     res.status(400).send({ err: 'startTime must precede endTime' });
   }
 
-  const condition = new Condition()
+  const condition = new Condition(`availability.${getDay()}`).exists()
     .where(`availability.${getDay()}.startTime`)
-    .le(startTime)
+    .le(reqStartTime).and()
     .where(`availability.${getDay()}.endTime`)
-    .ge(endTime);
+    .ge(reqEndTime);
 
+  console.log(`availability.${getDay()}`)
   db.scan(res, Driver, condition);
 });
 

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -49,15 +49,37 @@ router.get('/available', validateUser('Admin'), (req, res) => {
   const { date, reqStartTime, reqEndTime } = req.query;
   const startTime = moment(reqStartTime as string, 'HH:mm');
   const endTime = moment(reqEndTime as string, 'HH:mm');
-  const day = moment(date as string).day()
 
-  if (startTime > endTime) {
-    res.status(400).send({ err: 'startTime must precede endTime'})
+  function getDay() {
+    switch (moment(date as string).day()) {
+      case 0:
+        return 'Sun';
+      case 1:
+        return 'Mon';
+      case 2:
+        return 'Tue';
+      case 3:
+        return 'Wed';
+      case 4:
+        return 'Thu';
+      case 5:
+        return 'Fri';
+      case 6:
+        return 'Sat';
+    }
   }
 
-  const available = {};
+  if (startTime > endTime) {
+    res.status(400).send({ err: 'startTime must precede endTime' });
+  }
 
-  res.status(200).send(available);
+  const condition = new Condition()
+    .where(`availability.${getDay()}.startTime`)
+    .le(startTime)
+    .where(`availability.${getDay()}.endTime`)
+    .ge(endTime);
+
+  db.scan(res, Driver, condition);
 });
 
 // Get whether a driver is available at a given time

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid, validate } from 'uuid';
 import { Condition } from 'dynamoose';
 import { Document } from 'dynamoose/dist/Document';
 import moment from 'moment-timezone';
@@ -42,6 +42,14 @@ router.get('/:id/profile', validateUser('User'), (req, res) => {
       vehicle,
     });
   });
+});
+
+// Get all available drivers at a given time
+router.get('/available', validateUser('Admin'), (req, res) => {
+  const {date, startTime, endTime} = req.query;
+  const reqStart = moment(date as string + " " + startTime as string);
+  const reqEnd = moment(date as string + " " + endTime as string);
+  
 });
 
 // Get whether a driver is available at a given time

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -46,10 +46,18 @@ router.get('/:id/profile', validateUser('User'), (req, res) => {
 
 // Get all available drivers at a given time
 router.get('/available', validateUser('Admin'), (req, res) => {
-  const {date, startTime, endTime} = req.query;
-  const reqStart = moment(date as string + " " + startTime as string);
-  const reqEnd = moment(date as string + " " + endTime as string);
-  
+  const { date, reqStartTime, reqEndTime } = req.query;
+  const startTime = moment(reqStartTime as string, 'HH:mm');
+  const endTime = moment(reqEndTime as string, 'HH:mm');
+  const day = moment(date as string).day()
+
+  if (startTime > endTime) {
+    res.status(400).send({ err: 'startTime must precede endTime'})
+  }
+
+  const available = {};
+
+  res.status(200).send(available);
 });
 
 // Get whether a driver is available at a given time

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -33,7 +33,7 @@ router.get('/available', validateUser('User'), (req, res) => {
   ];
   const reqDate = numToDay[moment(date as string).day()];
 
-  if ((reqStartTime as string) >= (reqEndTime as string)) {
+  if (reqStartTime >= reqEndTime) {
     res.status(400).send({ err: 'startTime must precede endTime' });
   }
 
@@ -47,8 +47,8 @@ router.get('/available', validateUser('User'), (req, res) => {
       }
 
       return (
-        availEnd >= (reqEndTime as string) &&
-        availStart <= (reqStartTime as string)
+        availEnd >= reqEndTime &&
+        availStart <= reqStartTime
       );
     });
 

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -12,40 +12,13 @@ import { UserType } from '../models/subscription';
 const router = express.Router();
 const tableName = 'Drivers';
 
-// Get a driver by id in Drivers table
-router.get('/:id', validateUser('User'), (req, res) => {
-  const {
-    params: { id },
-  } = req;
-  db.getById(res, Driver, id, tableName);
-});
-
 // Get all drivers
 router.get('/', validateUser('Admin'), (req, res) => {
   db.getAll(res, Driver, tableName);
 });
 
-// Get profile information for a driver
-router.get('/:id/profile', validateUser('User'), (req, res) => {
-  const {
-    params: { id },
-  } = req;
-  db.getById(res, Driver, id, tableName, (driver: DriverType) => {
-    const { email, firstName, lastName, phoneNumber, availability, vehicle } =
-      driver;
-    res.send({
-      email,
-      firstName,
-      lastName,
-      phoneNumber,
-      availability,
-      vehicle,
-    });
-  });
-});
-
 // Get all available drivers at a specific date and time
-router.get('/test/available', validateUser('Admin'), (req, res) => {
+router.get('/available', validateUser('User'), (req, res) => {
   const { date, startTime: reqStartTime, endTime: reqEndTime } = req.query;
   const reqDay = moment(date as string).day();
 
@@ -75,12 +48,40 @@ router.get('/test/available', validateUser('Admin'), (req, res) => {
       if (availStart === undefined || availEnd === undefined) {
         return false;
       }
-      console.log(availEnd)
-      console.log(reqEndTime)
-      return availEnd >= (reqEndTime as string) && availStart <= (reqStartTime as string);
+      return (
+        availEnd >= (reqEndTime as string) &&
+        availStart <= (reqStartTime as string)
+      );
     });
 
     res.send(drivers);
+  });
+});
+
+// Get a driver by id in Drivers table
+router.get('/:id', validateUser('User'), (req, res) => {
+  const {
+    params: { id },
+  } = req;
+  db.getById(res, Driver, id, tableName);
+});
+
+// Get profile information for a driver
+router.get('/:id/profile', validateUser('User'), (req, res) => {
+  const {
+    params: { id },
+  } = req;
+  db.getById(res, Driver, id, tableName, (driver: DriverType) => {
+    const { email, firstName, lastName, phoneNumber, availability, vehicle } =
+      driver;
+    res.send({
+      email,
+      firstName,
+      lastName,
+      phoneNumber,
+      availability,
+      vehicle,
+    });
   });
 });
 

--- a/server/router/ride.ts
+++ b/server/router/ride.ts
@@ -332,7 +332,7 @@ router.put('/:id/edits', validateUser('User'), (req, res) => {
         db.update(res, Ride, { id }, update, tableName, handleEdit(update));
       }
     } else {
-      res.status(400).send({ err: 'Invalid operaton' });
+      res.status(400).send({ err: 'Invalid operation' });
     }
   });
 });


### PR DESCRIPTION
### Get available drivers

- [x] implemented `/api/drivers/available`

When given a date=YYYY-MM-DD, startTime=hh:mm, and endTime=hh:mm query, this endpoint should return a list of drivers that are available during this date and time range, based on a driver's availability.

### Test Plan <!-- Required -->

I called this endpoint on Postman and it runs successfully.
It is able to correctly filter out unavailable drivers.

### Notes <!-- Optional -->

1. This endpoint assumes there will not be drivers during weekends.
2. An empty list is returned when there is no drivers available.
3. Another possible output is `{err : 'startTime must precede endTime'}`