### PR TITLE
Add fields to push notif payload, remove rider notifs when reassigning drivers

### DIFF
--- a/frontend/src/components/Modal/AssignDriverModal.tsx
+++ b/frontend/src/components/Modal/AssignDriverModal.tsx
@@ -9,6 +9,7 @@ type AssignModalProps = {
   close: () => void;
   ride: Ride;
   allDrivers: Driver[];
+  reassign: boolean;
 };
 
 type DriverRowProps = {
@@ -33,6 +34,7 @@ const AssignDriverModal = ({
   close,
   ride,
   allDrivers,
+  reassign = false,
 }: AssignModalProps) => {
   const { withDefaults } = useReq();
   const { refreshRides } = useRides();
@@ -60,7 +62,7 @@ const AssignDriverModal = ({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           driver,
-          type: 'active',
+          type: !reassign ? 'active' : undefined,
         }),
       })
     ).then(() => refreshRides());

--- a/frontend/src/components/UserTables/RidesTable.tsx
+++ b/frontend/src/components/UserTables/RidesTable.tsx
@@ -16,6 +16,7 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
   const { drivers } = useEmployees();
   const [openAssignModal, setOpenAssignModal] = useState(-1);
   const [openEditModal, setOpenEditModal] = useState(-1);
+  const [reassign, setReassign] = useState(false);
 
   const unscheduledColSizes = [0.5, 0.5, 0.8, 1, 1, 0.8, 1];
   const unscheduledHeaders = [
@@ -78,13 +79,16 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
             ),
           };
 
-          const assignButton = (text: string) => (
+          const assignButton = (shouldReassign: boolean) => (
             <Button
               className={styles.assignButton}
-              onClick={() => setOpenAssignModal(index)}
+              onClick={() => {
+                setOpenAssignModal(index);
+                setReassign(shouldReassign);
+              }}
               small
             >
-              {text}
+              {shouldReassign ? 'Reassign' : 'Assign'}
             </Button>
           );
 
@@ -98,7 +102,7 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
             data: (
               <>
                 {editButton}
-                {assignButton('Assign')}
+                {assignButton(false)}
               </>
             ),
           };
@@ -107,7 +111,7 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
             data: (
               <>
                 {editButton}
-                {assignButton('Reassign')}
+                {assignButton(true)}
               </>
             ),
           };
@@ -151,6 +155,7 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
                 close={() => setOpenAssignModal(-1)}
                 ride={rides[index]}
                 allDrivers={drivers}
+                reassign={reassign}
               />
               <RideModal
                 open={openEditModal === index}

--- a/server/util/notification.ts
+++ b/server/util/notification.ts
@@ -90,6 +90,8 @@ const sendMsg = (
   const payload = JSON.stringify({
     default: 'Default message.',
     GCM: JSON.stringify({
+      priority: 'high',
+      content_available: true,
       data: {
         id: uuid(),
         notifEvent,
@@ -205,6 +207,9 @@ export const getNotificationEvent = (
   }
   if (type === Type.ACTIVE && driver) {
     return Change.SCHEDULED;
+  }
+  if (driver) {
+    return Change.REASSIGN_DRIVER;
   }
   return Change.EDITED;
 };

--- a/server/util/notification.ts
+++ b/server/util/notification.ts
@@ -96,6 +96,7 @@ const sendMsg = (
         id: uuid(),
         notifEvent,
         ride,
+        sentTime: new Date().toISOString(),
       },
       notification: {
         title,

--- a/server/util/types.ts
+++ b/server/util/types.ts
@@ -14,6 +14,7 @@ export enum Change {
   EDITED = 'edited',
   REPEATING_EDITED = 'repeating_edited',
   CREATED = 'created',
+  REASSIGN_DRIVER = 'reassign_driver',
 }
 
 export type NotificationEvent = Change | Status;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds some additional information to the push notification payload that is needed for the tap notification interaction. The `id` field makes sure the notification does not display more than once on the Notification page, and the `sentTime` field records the time the notification was created.

Additionally, some changes were made to the data sent when reassigning a driver, to prevent riders from getting notifications if a driver is reassigned.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

The only visible change is with reassigning drivers, so that's the only part that *needs* to be tested.

The push notification payload can be tested using `server/util/notification.test.ts`, using the id of a rider's ride in the database for `unscheduledRide`, but the only change is additional information, so it shouldn't break anything.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
