### PR TITLE
Fix time format so that one can schedule ride on Safari.

### DIFF
--- a/frontend/src/util/index.tsx
+++ b/frontend/src/util/index.tsx
@@ -13,7 +13,7 @@ export const format_date = (date?: string | Date, format?: string) => {
  *  is within the bounds of valid times given by CULift
  */
 export const checkBounds = (startDate: string, time: moment.Moment) => {
-  const earliest = moment(`${startDate} 7:30`);
+  const earliest = moment(`${startDate} 07:30`);
   const latest = moment(`${startDate} 22:00`);
   return earliest.isSameOrBefore(time) && latest.isSameOrAfter(time);
 };


### PR DESCRIPTION
### Summary <!-- Required -->

One-line fix to enable ride scheduling on Safari.

### Test Plan <!-- Required -->

Previously it won't work on safari and there is always a red message saying "invalid time" regardless of what the time actually is. Now it works fine on my Safari (latest macOS and Safari version).

