### PR TITLE
Suggest available drivers only

### DIFF
--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -28,9 +28,7 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
         .then((res) => res.json())
         .then((data) => {
           setAvailableDrivers(
-            [{ id: 'None', firstName: 'None', lastName: 'None' }].concat(
-              data.data
-            )
+            [{ id: 'None', firstName: 'None', lastName: 'None' }, ...data.data]
           );
           setLoaded(true);
         });

--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -13,11 +13,14 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
   });
   const { errors } = formState;
   const { withDefaults } = useReq();
-  const [refreshed, setRefreshed] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [hasDrivers, setHasDrivers] = useState(false);
 
   const { date, pickupTime: startTime, dropoffTime: endTime } = formData!;
   type DriverOption = { id: string; firstName: string; lastName: string };
-  const [availableDrivers, setAvailableDrivers] = useState<DriverOption[]>([]);
+  const [availableDrivers, setAvailableDrivers] = useState<DriverOption[]>([
+    { id: 'None', firstName: 'None', lastName: '' },
+  ]);
 
   useEffect(() => {
     if (startTime && endTime && date) {
@@ -28,7 +31,8 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
         .then((res) => res.json())
         .then((data) => {
           setAvailableDrivers(data.data);
-          setRefreshed(true);
+          setLoaded(true);
+          setHasDrivers(data.data.length >= 1);
         });
     }
   });
@@ -37,8 +41,8 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
     <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <div className={styles.inputContainer}>
         <div className={styles.drivers}>
-          {refreshed ? (
-            availableDrivers.length ? (
+          {loaded ? (
+            hasDrivers ? (
               availableDrivers.map((d) => (
                 <div className={styles.driver} key={d.id}>
                   <Label
@@ -61,7 +65,7 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
               <p>None</p>
             )
           ) : (
-            <p>Loading</p>
+            <p>Loading...</p>
           )}
         </div>
         {errors.driver?.type === 'required' && (

--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -34,7 +34,7 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
           setLoaded(true);
         });
     }
-  });
+  }, [startTime, endTime, date]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>

--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -15,26 +15,24 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
     },
   });
   const { errors } = formState;
-  const { drivers } = useEmployees();
+  // const { drivers } = useEmployees();
+
   const { date, startTime, endTime } = getValues();
   type DriverOption = { id: string; firstName: string; lastName: string };
-
-  if (!startTime || !endTime || !date) {
-    const availableDrivers = undefined;
-  } else {
-    const availableDrivers = fetch(`/api/drivers/available/${date}/${startTime}/${endTime}`)
+  let availableDrivers: DriverOption[] = [];
+  if (startTime && endTime && date) {
+    fetch(`/api/drivers/available/${date}/${startTime}/${endTime}`)
       .then((res) => res.json())
-      .then((data) => data.data);
+      .then((data) => {
+        availableDrivers = data;
+      });
   }
 
-  const driverOptions: DriverOption[] = [
-    { id: 'None', firstName: 'None', lastName: '' },
-  ].concat(drivers);
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <div className={styles.inputContainer}>
         <div className={styles.drivers}>
-          {driverOptions.map((d) => (
+          {availableDrivers.map((d) => (
             <div className={styles.driver} key={d.id}>
               <Label
                 htmlFor={d.firstName + d.lastName}

--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -13,54 +13,56 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
   });
   const { errors } = formState;
   const { withDefaults } = useReq();
+  const [refreshed, setRefreshed] = useState(false);
 
   const { date, pickupTime: startTime, dropoffTime: endTime } = formData!;
   type DriverOption = { id: string; firstName: string; lastName: string };
   const [availableDrivers, setAvailableDrivers] = useState<DriverOption[]>([]);
 
-  const getAvailableDrivers = async (
-    date: string | undefined,
-    startTime: string | undefined,
-    endTime: string | undefined
-  ) => {
+  useEffect(() => {
     if (startTime && endTime && date) {
-      await fetch(
+      fetch(
         `/api/drivers/available?date=${date}&startTime=${startTime}&endTime=${endTime}`,
         withDefaults()
       )
         .then((res) => res.json())
         .then((data) => {
           setAvailableDrivers(data.data);
+          setRefreshed(true);
         });
     }
-  }
-
-  useEffect(() => {
-    getAvailableDrivers(date, startTime, endTime);
   });
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <div className={styles.inputContainer}>
         <div className={styles.drivers}>
-          {availableDrivers.map((d) => (
-            <div className={styles.driver} key={d.id}>
-              <Label
-                htmlFor={d.firstName + d.lastName}
-                className={styles.driverLabel}
-              >
-                {d.firstName}
-              </Label>
-              <Input
-                id={d.firstName + d.lastName}
-                className={styles.driverRadio}
-                name="driver"
-                type="radio"
-                value={d.id}
-                ref={register({ required: true })}
-              />
-            </div>
-          ))}
+          {refreshed ? (
+            availableDrivers.length ? (
+              availableDrivers.map((d) => (
+                <div className={styles.driver} key={d.id}>
+                  <Label
+                    htmlFor={d.firstName + d.lastName}
+                    className={styles.driverLabel}
+                  >
+                    {d.firstName}
+                  </Label>
+                  <Input
+                    id={d.firstName + d.lastName}
+                    className={styles.driverRadio}
+                    name="driver"
+                    type="radio"
+                    value={d.id}
+                    ref={register({ required: true })}
+                  />
+                </div>
+              ))
+            ) : (
+              <p>None</p>
+            )
+          ) : (
+            <p>Loading</p>
+          )}
         </div>
         {errors.driver?.type === 'required' && (
           <p className={styles.error} style={{ textAlign: 'center' }}>

--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -27,9 +27,10 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
       )
         .then((res) => res.json())
         .then((data) => {
-          setAvailableDrivers(
-            [{ id: 'None', firstName: 'None', lastName: 'None' }, ...data.data]
-          );
+          setAvailableDrivers([
+            { id: 'None', firstName: 'None', lastName: 'None' },
+            ...data.data,
+          ]);
           setLoaded(true);
         });
     }

--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -14,13 +14,10 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
   const { errors } = formState;
   const { withDefaults } = useReq();
   const [loaded, setLoaded] = useState(false);
-  const [hasDrivers, setHasDrivers] = useState(false);
 
   const { date, pickupTime: startTime, dropoffTime: endTime } = formData!;
   type DriverOption = { id: string; firstName: string; lastName: string };
-  const [availableDrivers, setAvailableDrivers] = useState<DriverOption[]>([
-    { id: 'None', firstName: 'None', lastName: '' },
-  ]);
+  const [availableDrivers, setAvailableDrivers] = useState<DriverOption[]>([]);
 
   useEffect(() => {
     if (startTime && endTime && date) {
@@ -30,9 +27,12 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
       )
         .then((res) => res.json())
         .then((data) => {
-          setAvailableDrivers(data.data);
+          setAvailableDrivers(
+            [{ id: 'None', firstName: 'None', lastName: 'None' }].concat(
+              data.data
+            )
+          );
           setLoaded(true);
-          setHasDrivers(data.data.length >= 1);
         });
     }
   });
@@ -42,28 +42,24 @@ const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
       <div className={styles.inputContainer}>
         <div className={styles.drivers}>
           {loaded ? (
-            hasDrivers ? (
-              availableDrivers.map((d) => (
-                <div className={styles.driver} key={d.id}>
-                  <Label
-                    htmlFor={d.firstName + d.lastName}
-                    className={styles.driverLabel}
-                  >
-                    {d.firstName}
-                  </Label>
-                  <Input
-                    id={d.firstName + d.lastName}
-                    className={styles.driverRadio}
-                    name="driver"
-                    type="radio"
-                    value={d.id}
-                    ref={register({ required: true })}
-                  />
-                </div>
-              ))
-            ) : (
-              <p>None</p>
-            )
+            availableDrivers.map((d) => (
+              <div className={styles.driver} key={d.id}>
+                <Label
+                  htmlFor={d.firstName + d.lastName}
+                  className={styles.driverLabel}
+                >
+                  {d.firstName}
+                </Label>
+                <Input
+                  id={d.firstName + d.lastName}
+                  className={styles.driverRadio}
+                  name="driver"
+                  type="radio"
+                  value={d.id}
+                  ref={register({ required: true })}
+                />
+              </div>
+            ))
           ) : (
             <p>Loading...</p>
           )}

--- a/frontend/src/components/RideModal/Pages/Driver.tsx
+++ b/frontend/src/components/RideModal/Pages/Driver.tsx
@@ -6,12 +6,27 @@ import { Label, Input, Button } from '../../FormElements/FormElements';
 import { useEmployees } from '../../../context/EmployeesContext';
 
 const DriverPage = ({ onBack, onSubmit, formData }: ModalPageProps) => {
-  const { register, handleSubmit, formState } = useForm({
-    defaultValues: { driver: formData?.driver ?? '' },
+  const { register, handleSubmit, formState, getValues } = useForm({
+    defaultValues: {
+      driver: formData?.driver ?? '',
+      date: formData?.date ?? '',
+      startTime: formData?.startTime ?? '',
+      endTime: formData?.endTime ?? '',
+    },
   });
   const { errors } = formState;
   const { drivers } = useEmployees();
+  const { date, startTime, endTime } = getValues();
   type DriverOption = { id: string; firstName: string; lastName: string };
+
+  if (!startTime || !endTime || !date) {
+    const availableDrivers = undefined;
+  } else {
+    const availableDrivers = fetch(`/api/drivers/available/${date}/${startTime}/${endTime}`)
+      .then((res) => res.json())
+      .then((data) => data.data);
+  }
+
   const driverOptions: DriverOption[] = [
     { id: 'None', firstName: 'None', lastName: '' },
   ].concat(drivers);


### PR DESCRIPTION
### Summary

Previously, the ride scheduling modal lists all drivers as available drivers regardless of their actual availability. This PR fixes this and only allows the drivers who's availability matches the date, pickupTime, and dropoffTime selected by the user. Availability data is based on the backend endpoint `/api/drivers/available` which I implemented during the winter break.

Since displaying available drivers is now an asynchronous function, I let the modal first display "loading" and then transition to either "none" or a list of actually available drivers. The process takes about half-second on my local servers.


### Test Plan 

It looks good on my side :stuck_out_tongue_winking_eye:. Here's some pics:
![image](https://user-images.githubusercontent.com/76980494/151685640-b762fd2c-ae98-4863-82e1-4b0de9c84a6c.png)
![image](https://user-images.githubusercontent.com/76980494/151685643-100afb12-859b-4598-b872-4e9ac08c1be7.png)
![image](https://user-images.githubusercontent.com/76980494/151685646-355a378e-8c5c-42a8-9dec-f2cdf23cd303.png)



### Notes <!-- Optional -->

It seems that the ride is not listed under "scheduled riders" somehow. But I switched back to the master branch and the problem still exists, so it's likely not a problem of this PR.