### PR TITLE
Rider object reduced tag setting

### DIFF
--- a/frontend/src/components/TableComponents/TableComponents.tsx
+++ b/frontend/src/components/TableComponents/TableComponents.tsx
@@ -54,7 +54,7 @@ export const Row = ({
   header,
   groupStart,
   className,
-  onClick,
+  onClick
 }: RowProps) => {
   const { width } = useWindowSize();
   const isMobile = Boolean(width && width < 700);
@@ -70,8 +70,8 @@ export const Row = ({
       if (typeof cell === 'string') {
         return <Cell key={idx} data={cell} />;
       }
-      const { data: cData, tag, smallTag } = cell;
-      return <Cell key={idx} data={cData} tag={tag} smallTag={smallTag} />;
+      const { data: cData, tag } = cell;
+      return <Cell key={idx} data={cData} tag={tag} smallTag={true} />;
     });
 
   if (!header && groupStart) {
@@ -94,11 +94,11 @@ export const Row = ({
             !isMobile
               ? {
                   gridTemplateColumns: formatColSizes(nonGroupCols),
-                  gridColumn: `1 / ${groupStart + 1}`,
+                  gridColumn: `1 / ${groupStart + 1}`
                 }
               : {
                   gridTemplateRows: formatRowSizes(nonGroupCols),
-                  gridRow: `1 / ${groupStart + 1}`,
+                  gridRow: `1 / ${groupStart + 1}`
                 }
           }
         >
@@ -110,11 +110,11 @@ export const Row = ({
             !isMobile
               ? {
                   gridTemplateColumns: formatColSizes(groupCols),
-                  gridColumn: `${groupStart + 1} / -1`,
+                  gridColumn: `${groupStart + 1} / -1`
                 }
               : {
                   gridTemplateRows: formatRowSizes(groupCols),
-                  gridRow: `${groupStart + 1} / -1`,
+                  gridRow: `${groupStart + 1} / -1`
                 }
           }
         >
@@ -135,11 +135,11 @@ export const Row = ({
           ? {
               gridTemplateColumns: formatColSizes(colSizes),
               cursor: onClick ? 'pointer' : undefined,
-              width: '100%',
+              width: '100%'
             }
           : {
               gridTemplateRows: formatRowSizes(colSizes),
-              cursor: onClick ? 'pointer' : undefined,
+              cursor: onClick ? 'pointer' : undefined
             }
       }
     >

--- a/frontend/src/components/TableComponents/TableComponents.tsx
+++ b/frontend/src/components/TableComponents/TableComponents.tsx
@@ -54,7 +54,7 @@ export const Row = ({
   header,
   groupStart,
   className,
-  onClick
+  onClick,
 }: RowProps) => {
   const { width } = useWindowSize();
   const isMobile = Boolean(width && width < 700);
@@ -94,11 +94,11 @@ export const Row = ({
             !isMobile
               ? {
                   gridTemplateColumns: formatColSizes(nonGroupCols),
-                  gridColumn: `1 / ${groupStart + 1}`
+                  gridColumn: `1 / ${groupStart + 1}`,
                 }
               : {
                   gridTemplateRows: formatRowSizes(nonGroupCols),
-                  gridRow: `1 / ${groupStart + 1}`
+                  gridRow: `1 / ${groupStart + 1}`,
                 }
           }
         >
@@ -110,11 +110,11 @@ export const Row = ({
             !isMobile
               ? {
                   gridTemplateColumns: formatColSizes(groupCols),
-                  gridColumn: `${groupStart + 1} / -1`
+                  gridColumn: `${groupStart + 1} / -1`,
                 }
               : {
                   gridTemplateRows: formatRowSizes(groupCols),
-                  gridRow: `${groupStart + 1} / -1`
+                  gridRow: `${groupStart + 1} / -1`,
                 }
           }
         >
@@ -135,11 +135,11 @@ export const Row = ({
           ? {
               gridTemplateColumns: formatColSizes(colSizes),
               cursor: onClick ? 'pointer' : undefined,
-              width: '100%'
+              width: '100%',
             }
           : {
               gridTemplateRows: formatRowSizes(colSizes),
-              cursor: onClick ? 'pointer' : undefined
+              cursor: onClick ? 'pointer' : undefined,
             }
       }
     >

--- a/frontend/src/components/Tag/tag.module.css
+++ b/frontend/src/components/Tag/tag.module.css
@@ -2,6 +2,9 @@
   height: 11px;
   width: 11px;
   float: left;
+  position: relative;
+  top: 0.4rem;
+  line-height: 1;
   border-radius: 50%;
 }
 

--- a/frontend/src/components/Tag/tag.module.css
+++ b/frontend/src/components/Tag/tag.module.css
@@ -1,9 +1,9 @@
 .reducedTag {
   height: 11px;
   width: 11px;
-  float: left;
-  position: relative;
-  top: 0.4rem;
+  display: inline-block;
+  margin-left: 6px;
+  margin-right: 5px;
   line-height: 1;
   border-radius: 50%;
 }


### PR DESCRIPTION
### Summary changing the ride tag
Set the reduced tag for the ride object to be the default and position it to be aligned with line-height of the adjacent text.


