### PR TITLE
Available drivers only allow drivers not already scheduled for a ride

### DIFF
--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -43,18 +43,18 @@ router.get('/available', validateUser('User'), (req, res) => {
     .group((condition) =>
       condition
         .where('startTime')
-        .ge(startTime)
-        .le(endTime)
+        .ge(reqStartTime)
+        .le(reqEndTime)
         .or()
         .where('endTime')
-        .ge(startTime)
-        .le(endTime)
+        .ge(reqStartTime)
+        .le(reqEndTime)
         .or()
         .where('startTime')
-        .le(startTime)
+        .le(reqStartTime)
         .and()
         .where('endTime')
-        .ge(endTime)
+        .ge(reqEndTime)
     );
   let allRides: RideType[];
   db.scan(res, Ride, condition, (rides) => {

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -32,6 +32,21 @@ router.get('/available', validateUser('User'), (req, res) => {
     undefined,
   ];
   const reqDate = numToDay[moment(date as string).day()];
+  const condition = new Condition('status')
+    .not()
+    .eq(Status.CANCELLED)
+    .and()
+    .where('startTime')
+    .ge(startTime)
+    .le(endTime)
+    .or()
+    .where('endTime')
+    .ge(startTime)
+    .le(endTime);
+  let allRides = [];
+  db.scan(res, Ride, condition, (rides) => {
+    allRides = rides;
+  });
 
   if (reqStartTime >= reqEndTime) {
     res.status(400).send({ err: 'startTime must precede endTime' });

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -46,7 +46,13 @@ router.get('/available', validateUser('User'), (req, res) => {
     .or()
     .where('endTime')
     .ge(startTime)
-    .le(endTime);
+    .le(endTime)
+    .or()
+    .where('startTime')
+    .le(startTime)
+    .and()
+    .where('endTime')
+    .ge(endTime);
   let allRides: RideType[];
   db.scan(res, Ride, condition, (rides) => {
     allRides = rides;

--- a/server/router/driver.ts
+++ b/server/router/driver.ts
@@ -40,19 +40,22 @@ router.get('/available', validateUser('User'), (req, res) => {
     .not()
     .eq(Status.CANCELLED)
     .and()
-    .where('startTime')
-    .ge(startTime)
-    .le(endTime)
-    .or()
-    .where('endTime')
-    .ge(startTime)
-    .le(endTime)
-    .or()
-    .where('startTime')
-    .le(startTime)
-    .and()
-    .where('endTime')
-    .ge(endTime);
+    .group((condition) =>
+      condition
+        .where('startTime')
+        .ge(startTime)
+        .le(endTime)
+        .or()
+        .where('endTime')
+        .ge(startTime)
+        .le(endTime)
+        .or()
+        .where('startTime')
+        .le(startTime)
+        .and()
+        .where('endTime')
+        .ge(endTime)
+    );
   let allRides: RideType[];
   db.scan(res, Ride, condition, (rides) => {
     allRides = rides;


### PR DESCRIPTION
### Summary 

Endpoint `/available` now has a new rule. It filters out drivers who's availability matches the requested ride but are already scheduled for a ride for that time interval.
This is done by scanning the database using dynamoose conditions and moment.js formats.
Tested by printing out the rides that are filtered out. Result seems reasonable.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
