### PR TITLE
Fix batchGet function

### DIFF
--- a/server/router/common.ts
+++ b/server/router/common.ts
@@ -32,18 +32,19 @@ export function batchGet(
 ) {
   if (!keys.length) {
     res.send({ data: [] });
+  } else {
+    model.batchGet(keys, (err, data) => {
+      if (err) {
+        res.status(err.statusCode || 500).send({ err: err.message });
+      } else if (!data) {
+        res.status(400).send({ err: `items not found in ${table}` });
+      } else if (callback) {
+        data.populate().then((doc) => callback(doc));
+      } else {
+        data.populate().then((doc) => res.status(200).send({ data: doc }));
+      }
+    });
   }
-  model.batchGet(keys, (err, data) => {
-    if (err) {
-      res.status(err.statusCode || 500).send({ err: err.message });
-    } else if (!data) {
-      res.status(400).send({ err: `items not found in ${table}` });
-    } else if (callback) {
-      data.populate().then((doc) => callback(doc));
-    } else {
-      data.populate().then((doc) => res.status(200).send({ data: doc }));
-    }
-  });
 }
 
 export function getAll(


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the batchGet function, used in the `/api/riders/<id>/favorites` endpoint, which causes the server to crash. Without the `else` block, `batchGet` would try to send two responses, as seen in the error below.

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/20343975/156284137-4635e31b-accb-4b94-bee0-d8005d1bb5aa.png">

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Make a request to `/api/riders/<id>/favorites`.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
