### PR TITLE
formatting the edit student modal

### DIFF
--- a/frontend/src/components/Modal/RiderModal.tsx
+++ b/frontend/src/components/Modal/RiderModal.tsx
@@ -82,7 +82,7 @@ const RiderModal = ({ existingRider, isRiderWeb }: RiderModalProps) => {
         </button>
       )}
       <Modal
-        title={!existingRider ? 'Add a Student' : 'Edit a Student'}
+        title={!existingRider ? 'Add a Student' : 'Edit Student'}
         isOpen={isOpen}
         currentPage={0}
         onClose={closeModal}

--- a/frontend/src/components/Modal/RiderModalInfo.tsx
+++ b/frontend/src/components/Modal/RiderModalInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import cn from 'classnames';
-import { Button, Input, Label } from '../FormElements/FormElements';
+import { Button, Input, Label, SRLabel } from '../FormElements/FormElements';
 import styles from './ridermodal.module.css';
 import { ObjectType, Accessibility, Rider } from '../../types/index';
 
@@ -81,6 +81,8 @@ const RiderModalInfo = ({
           {errors.firstName && (
             <p className={styles.error}>Please enter a name</p>
           )}
+        </div>
+        <div className={cn(styles.gridR1, styles.gridCSmall2)}>
           <Label className={styles.label} htmlFor="lastName">
             Last Name:{' '}
           </Label>
@@ -95,7 +97,7 @@ const RiderModalInfo = ({
             <p className={styles.error}>Please enter a name</p>
           )}
         </div>
-        <div className={cn(styles.gridR1, styles.gridCSmall2)}>
+        <div className={cn(styles.gridR1, styles.gridCSmall3)}>
           <Label className={styles.label} htmlFor="netid">
             NetID:{' '}
           </Label>
@@ -109,7 +111,7 @@ const RiderModalInfo = ({
           />
           {errors.netid && <p className={styles.error}>Please enter a netid</p>}
         </div>
-        <div className={cn(styles.gridR1, styles.gridCSmall3)}>
+        <div className={cn(styles.gridR1, styles.gridCSmall4)}>
           <Label className={styles.label} htmlFor="phoneNumber">
             Phone Number:{' '}
           </Label>
@@ -219,7 +221,7 @@ const RiderModalInfo = ({
           Cancel
         </Button>
         <Button type="submit" className={styles.submit}>
-          {isEditing ? 'Edit a Student' : 'Add a Student'}
+          {isEditing ? 'Edit Student' : 'Add a Student'}
         </Button>
       </div>
     </form>

--- a/frontend/src/components/Modal/ridermodal.module.css
+++ b/frontend/src/components/Modal/ridermodal.module.css
@@ -29,11 +29,15 @@
   grid-column: 5 / span 2;
 }
 
+.girdCSmall4 {
+  grid-column: 7 / span 2;
+}
+
 .gridCBig1 {
   grid-column: 1 / span 3;
 }
 .gridCBig2 {
-  grid-column: 4 / span 3;
+  grid-column: 5 / span 3;
 }
 .gridCAll {
   grid-column: 1 / span 6;
@@ -46,8 +50,9 @@
 .to {
   font-size: 0.9rem;
   grid-column: 3 / span 1;
-  margin-left: 70%;
-  margin-top: 5%;
+  margin-top: 1.75rem;
+  margin-right: 1.5rem;
+  /* margin: 0 1rem; */
 }
 
 .end {
@@ -58,6 +63,7 @@
   grid-row: 1;
 }
 .gridR2 {
+  margin-top: 1.2rem;
   grid-row: 2;
 }
 .gridR3 {
@@ -75,15 +81,12 @@
 }
 
 .firstRow {
+  display: flex;
   max-width: 90%;
 }
 
 .lastRow {
   display: flex;
-}
-
-.to {
-  margin: 0 1rem;
 }
 
 .buttonContainer {


### PR DESCRIPTION
### Summary <!-- Required -->

I formatted the edit student modal so that it would match the Figma screen a little more.  
<img width="726" alt="Screen Shot 2022-03-20 at 6 50 35 PM" src="https://user-images.githubusercontent.com/88568615/159189485-06fdcdb4-8469-46b8-a92e-773758dc1451.png">


### Test Plan <!-- Required -->

### Notes <!-- Optional -->

I am a little unsure if I formatted everything the way that we'd want it to be because the textboxes are meant to stay, but they are not present in the Figma. Changes can easily be made in the future if they are not satisfactory though.


