### PR TITLE
Update README with some Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
   - [About](#about)
   - [Contributors:](#contributors)
 
+## Docs
+
+After cloning the repository, run:
+`npm run install:server`
+`npm run install:frontend`
+`npm run start:server`
+`npm run start:frontend`
+This will start an instance running locally.
+
+To restart the Dyno from Heroku CLI:
+`heroku dyno:restart -a carriage-web`
+
 ## About
 
 If you have a disability that prevents you from walking around campus, getting around can be difficult. This is a **Web** app that helps dispatchers of Cornell's CULift to schedule, edit, and manage all CULift and RedRunner rides.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
 ## Docs
 
+Carriage documentation is located at our [Notion](https://dti-carriage.notion.site/DTI-Carriage-Wiki-e10ea27fa06f4cbbb3fcd57873d331e6).
+
+Want to run this locally? From our [Useful Commands page](https://dti-carriage.notion.site/Useful-Commands-b20422d052b444d396b04a6df4debc07).
 After cloning the repository, run:
 `npm run install:server`
 `npm run install:frontend`
 `npm run start:server`
 `npm run start:frontend`
 This will start an instance running locally.
-
-To restart the Dyno from Heroku CLI:
-`heroku dyno:restart -a carriage-web`
 
 ## About
 


### PR DESCRIPTION
### Summary

Updated README with a comprehensive new set of Docs for the entire Carriage team, migrating from two largely unorganized Google Docs in the Dev folder in GDrive to a modern updatable wiki-style framework.

Also, brought out the most commonly used local development commands and dumped them in the README as well for ease of access.
