### PR TITLE
Added Page Titles

### DIFF
--- a/frontend/src/components/UserDetail/EmployeeDetail.tsx
+++ b/frontend/src/components/UserDetail/EmployeeDetail.tsx
@@ -173,6 +173,14 @@ const EmployeeDetail = () => {
   };
 
   useEffect(() => {
+    if (employee) {
+      document.title = `${employee.firstName} ${employee.lastName} - Carriage`;
+    } else {
+      document.title = 'Employee Details - Carriage';
+    }
+  }, [employee]);
+
+  useEffect(() => {
     if (!employee && employeeId) {
       if (userType === 'admins') {
         fetch(`/api/admins/${employeeId}`, withDefaults())

--- a/frontend/src/components/UserDetail/RiderDetail.tsx
+++ b/frontend/src/components/UserDetail/RiderDetail.tsx
@@ -46,6 +46,14 @@ const RiderDetail = () => {
     moment(date).format('MM/DD/YYYY');
 
   useEffect(() => {
+    if (rider) {
+      document.title = `${rider.firstName} ${rider.lastName} - Carriage`;
+    } else {
+      document.title = 'Rider Details - Carriage';
+    }
+  }, [rider]);
+
+  useEffect(() => {
     if (riderId) {
       if (!rider) {
         fetch(`/api/riders/${riderId}`, withDefaults())

--- a/frontend/src/pages/Admin/Analytics.tsx
+++ b/frontend/src/pages/Admin/Analytics.tsx
@@ -18,6 +18,10 @@ const Analytics = () => {
   const [startDate, setStartDate] = useState(today.format('YYYY-MM-DD'));
   const [endDate, setEndDate] = useState(today.format('YYYY-MM-DD'));
 
+  React.useEffect(() => {
+    document.title = 'Analytics - Carriage';
+  });
+
   const refreshTable = (start = startDate, end = endDate) => {
     fetch(`/api/stats/?from=${start}&to=${end}`, withDefaults())
       .then((res) => res.json())

--- a/frontend/src/pages/Admin/Employees.tsx
+++ b/frontend/src/pages/Admin/Employees.tsx
@@ -1,20 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import EmployeeModal from '../../components/EmployeeModal/EmployeeModal';
 import EmployeeCards from '../../components/EmployeeCards/EmployeeCards';
 import styles from './page.module.css';
 import Notification from '../../components/Notification/Notification';
 
-const Employees = () => (
-  <main id="main">
-    <div className={styles.pageTitle}>
-      <h1 className={styles.header}>Employees</h1>
-      <div className={styles.rightSection}>
-        <EmployeeModal />
-        <Notification />
+const Employees = () => {
+  useEffect(() => {
+    document.title = 'Employees - Carriage';
+  });
+
+  return (
+    <main id="main">
+      <div className={styles.pageTitle}>
+        <h1 className={styles.header}>Employees</h1>
+        <div className={styles.rightSection}>
+          <EmployeeModal />
+          <Notification />
+        </div>
       </div>
-    </div>
-    <EmployeeCards />
-  </main>
-);
+      <EmployeeCards />
+    </main>
+  );
+};
 
 export default Employees;

--- a/frontend/src/pages/Admin/Home.tsx
+++ b/frontend/src/pages/Admin/Home.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import moment from 'moment';
 import RideModal from '../../components/RideModal/RideModal';
 import ScheduledTable from '../../components/UserTables/ScheduledTable';
@@ -15,6 +15,10 @@ import { format_date } from '../../util/index';
 const Home = () => {
   const { curDate } = useDate();
   const today = format_date(curDate);
+
+  useEffect(() => {
+    document.title = 'Home - Carriage';
+  });
 
   return (
     <main id="main">

--- a/frontend/src/pages/Admin/Locations.tsx
+++ b/frontend/src/pages/Admin/Locations.tsx
@@ -12,6 +12,10 @@ const Locations = () => {
   const loc = useLocations().locations;
 
   useEffect(() => {
+    document.title = 'Locations - Carriage';
+  });
+
+  useEffect(() => {
     setLocations(loc);
   }, [loc]);
 

--- a/frontend/src/pages/Admin/Students.tsx
+++ b/frontend/src/pages/Admin/Students.tsx
@@ -7,6 +7,10 @@ import Notification from '../../components/Notification/Notification';
 import styles from './page.module.css';
 
 const Riders = () => {
+  React.useEffect(() => {
+    document.title = 'Students - Carriage';
+  });
+
   const [searchName, setSearchName] = useState<string>('');
   return (
     <main id="main">


### PR DESCRIPTION
### Summary 

Pages have been renamed according to a more descriptive design scheme. Overview pages (that list lots of smaller rows of data, for instance) have been renamed to "[Page] - Carriage." Specific pages (eg. for Carl Chen's Employee page) have been renamed to "[FName LName] - Carriage."

This was done with a simple useEffect on each relevant component that set document.title depending on either the component it's in, or the relevant object (as long as it's !undefined) (eg. rider, employee).

### Test Plan <!-- Required -->

N/A - Frontend Only
