### PR TITLE
Update Collapsible to comply with Accordion ARIA

### DIFF
--- a/frontend/src/components/Collapsible/Collapsible.tsx
+++ b/frontend/src/components/Collapsible/Collapsible.tsx
@@ -12,7 +12,8 @@ const Collapsible = ({ title, children }: CollapsibleSection) => {
   const icon = expanded ? down : up;
 
   const handleKeywordKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
+    e.preventDefault();
+    if (e.key === 'Enter' || e.key === ' ') {
       setExpanded(!expanded);
     }
   };
@@ -24,6 +25,7 @@ const Collapsible = ({ title, children }: CollapsibleSection) => {
         aria-expanded={expanded}
         aria-controls={`region-${title}`}
         onClick={() => setExpanded(!expanded)}
+        onKeyPress={handleKeywordKeyPress}
         tabIndex={0}
       >
         <h2 className={styles.title}>{title}</h2>
@@ -32,7 +34,6 @@ const Collapsible = ({ title, children }: CollapsibleSection) => {
           src={icon}
           aria-hidden={true}
           tabIndex={-1}
-          onKeyPress={handleKeywordKeyPress}
         />
       </div>
       {expanded && (

--- a/frontend/src/components/Collapsible/Collapsible.tsx
+++ b/frontend/src/components/Collapsible/Collapsible.tsx
@@ -18,18 +18,32 @@ const Collapsible = ({ title, children }: CollapsibleSection) => {
   };
   return (
     <div className={styles.collapsible}>
-      <div className={styles.banner} onClick={() => setExpanded(!expanded)}>
+      <div
+        className={styles.banner}
+        role={'button'}
+        aria-expanded={expanded}
+        aria-controls={`region-${title}`}
+        onClick={() => setExpanded(!expanded)}
+        tabIndex={0}
+      >
         <h2 className={styles.title}>{title}</h2>
         <img
           className={styles.icon}
           src={icon}
-          role={'button'}
-          alt={'see more'}
-          tabIndex={0}
+          aria-hidden={true}
+          tabIndex={-1}
           onKeyPress={handleKeywordKeyPress}
         />
       </div>
-      {expanded && <div className={styles.contentContainer}>{children}</div>}
+      {expanded && (
+        <div
+          className={styles.contentContainer}
+          role="region"
+          id={`region-${title}`}
+        >
+          {children}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Trello tasks
[Accordion lacks expected WAI-ARIA markup](https://trello.com/c/Fa8piCvR/399-accordion-lacks-expected-wai-aria-markup)
and
[Accordions contain an ambiguous See More button that lacks description of its purpose](https://trello.com/c/KLpNgEwz/400-accordions-contain-an-ambiguous-see-more-button-that-lacks-description-of-its-purpose)



### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards improving the screenreader accessibility of the Collapsible component to comply with the ARIA specs for Accordions (https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion.html)

- [x] Move button role to the header div with the title and button
- [x] Add aria-expanded and aria-controls according to ARIA specs
- [x] Add tabindex -1 and aria-hidden on icon button to avoid duplicate buttons since the header div acts as the button
- [x] Add role of region to the content of the Collapsible according to ARIA specs   

### Test Plan <!-- Required -->

Tested with NVDA:
1. Focus on Your Upcoming Rides: "Your Upcoming Rides, heading 2, button collapsed"
2. Toggle with space or enter: "Expanded" / "Collapsed"

### Notes <!-- Optional -->

* Need help testing with VoiceOver from someone with a Mac
* The ID being 'region' + the title of the section is a little questionable, but I need a unique ID and I'm guessing the title will always be unique; if this isn't the case then we can add ID as a parameter and always set it ourselves

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
