### PR TITLE
removed overriding of outline style

### DIFF
--- a/frontend/src/components/AnalyticsTable/analyticstable.module.css
+++ b/frontend/src/components/AnalyticsTable/analyticstable.module.css
@@ -36,5 +36,4 @@
   text-align: center;
   width: 3.5rem;
   font-size: 1rem;
-  outline: none;
 }

--- a/frontend/src/components/EmployeeModal/employeemodal.module.css
+++ b/frontend/src/components/EmployeeModal/employeemodal.module.css
@@ -77,7 +77,6 @@
   cursor: pointer;
   background-color: white;
   border: none;
-  outline: none;
 }
 
 .addAvailabilityInput:hover {
@@ -117,7 +116,6 @@
   border: none;
   padding: 0;
   cursor: pointer;
-  outline: none;
   margin: 0 0.125rem;
   background-color: rgba(0, 0, 0, 0.1);
 }

--- a/frontend/src/components/FormElements/formelements.module.css
+++ b/frontend/src/components/FormElements/formelements.module.css
@@ -4,7 +4,6 @@
 
 .input {
   border: 1px solid black;
-  outline: none;
   border-radius: 0.25rem;
 }
 
@@ -36,7 +35,6 @@
   padding: 0.5rem 1rem;
   text-align: center;
   font-size: 0.9375rem;
-  outline: none;
   cursor: pointer;
 }
 
@@ -46,7 +44,6 @@
   padding: 0.375rem 0.75rem;
   text-align: center;
   font-size: 0.875rem;
-  outline: none;
   cursor: pointer;
 }
 

--- a/frontend/src/components/Modal/modal.module.css
+++ b/frontend/src/components/Modal/modal.module.css
@@ -26,7 +26,6 @@
 
 .closeBtn {
   border: none;
-  outline: none;
   cursor: pointer;
   background: none;
   padding: 0;

--- a/frontend/src/components/RequestRideModal/requestridemodal.module.css
+++ b/frontend/src/components/RequestRideModal/requestridemodal.module.css
@@ -30,6 +30,9 @@
 .box {
   display: flex;
 }
+.btn {
+  margin-right: 10px;
+}
 .dayBox {
   display: flex;
 }

--- a/frontend/src/components/RequestRideModal/requestridemodal.module.css
+++ b/frontend/src/components/RequestRideModal/requestridemodal.module.css
@@ -53,7 +53,6 @@
   border: none;
   padding: 0;
   cursor: pointer;
-  outline: none;
   margin: 0 0.125rem;
   background-color: rgba(0, 0, 0, 0.1);
 }

--- a/frontend/src/components/RideModal/ridemodal.module.css
+++ b/frontend/src/components/RideModal/ridemodal.module.css
@@ -54,7 +54,6 @@
   border: none;
   padding: 0;
   cursor: pointer;
-  outline: none;
   margin: 0 0.125rem;
   background-color: rgba(0, 0, 0, 0.1);
 }

--- a/frontend/src/components/Schedule/schedule.module.css
+++ b/frontend/src/components/Schedule/schedule.module.css
@@ -58,7 +58,6 @@
   margin: auto;
   width: 2.25rem;
   height: 2.25rem;
-  outline: none;
 }
 
 .btn:hover {

--- a/frontend/src/components/SearchBar/searchbar.module.css
+++ b/frontend/src/components/SearchBar/searchbar.module.css
@@ -17,13 +17,11 @@
   margin-top: 0.4rem;
   border-width: 0px;
   border: none;
-  outline: none;
   margin-left: 1rem;
 }
 .searchBar {
   border-width: 0px;
   border: none;
-  outline: none;
   font-style: normal;
   font-weight: 600;
   font-size: 20px;

--- a/frontend/src/components/Sidebar/sidebar.module.css
+++ b/frontend/src/components/Sidebar/sidebar.module.css
@@ -82,7 +82,6 @@
   margin: auto;
   background-color: Transparent;
   border: none;
-  outline: none;
 }
 .logoutLink:focus {
   outline: 3px solid #0075db;

--- a/frontend/src/components/TabSwitcher/tabSwitcher.module.css
+++ b/frontend/src/components/TabSwitcher/tabSwitcher.module.css
@@ -7,7 +7,6 @@
   padding: 0 0.6rem 0.25rem 0.6rem;
   background-color: #fff;
   border: none;
-  outline: none;
 }
 
 .tab:hover {


### PR DESCRIPTION
## Trello Task
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;VC4ymVxJ&#x2F;402-best-practice-will-not-override-browser-focus-outline-indicator">Best practice will not override browser focus outline indicator.</a></blockquote>

### Summary
- removed overriding of outline style in the request-a-ride module

### Doubt!
- There are more such places where outline styling is overridden. should i remove them as well?