### PR TITLE
fixed undefined rider name

### DIFF
--- a/frontend/src/components/RideModal/RideModal.tsx
+++ b/frontend/src/components/RideModal/RideModal.tsx
@@ -164,8 +164,6 @@ const RideModal = ({ open, close, ride, editSingle }: RideModalProps) => {
         };
       }
 
-      console.log(rideData.rider);
-
       if (ride) {
         // scheduled ride
         if (ride.type === 'active') {

--- a/frontend/src/components/RideModal/RideModal.tsx
+++ b/frontend/src/components/RideModal/RideModal.tsx
@@ -164,7 +164,7 @@ const RideModal = ({ open, close, ride, editSingle }: RideModalProps) => {
         };
       }
 
-      console.log(rideData);
+      console.log(rideData.rider);
 
       if (ride) {
         // scheduled ride

--- a/frontend/src/components/UserTables/RidesTable.tsx
+++ b/frontend/src/components/UserTables/RidesTable.tsx
@@ -8,6 +8,7 @@ import styles from './table.module.css';
 import { useEmployees } from '../../context/EmployeesContext';
 import DeleteOrEditTypeModal from '../Modal/DeleteOrEditTypeModal';
 import { trashbig } from '../../icons/other/index';
+import { useRiders } from '../../context/RidersContext';
 
 type RidesTableProps = {
   rides: Ride[];
@@ -60,9 +61,16 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
             hour: '2-digit',
             minute: '2-digit',
           });
+          // Line 65 only returns the id of the rider of the ride
           const { rider } = ride;
-          const riderName = rider ? `${rider.firstName} ${rider.lastName}` : '';
-          const needs = rider ? rider.accessibility || '' : '';
+          const ridersInfo = useRiders();
+          const riderInfo = ridersInfo.riders.filter(
+            (x) => String(rider) == x.id
+          )[0];
+          const riderName = riderInfo
+            ? `${riderInfo.firstName} ${riderInfo.lastName}`
+            : '';
+          const needs = riderInfo ? riderInfo.accessibility || '' : '';
           const pickupLocation = ride.startLocation.name;
           const pickupTag = ride.startLocation.tag;
           const dropoffLocation = ride.endLocation.name;


### PR DESCRIPTION
### Summary <!-- Required -->

There was an issue before where the rider's name would not be displayed on the home page when viewing all of the rides scheduled for the day. Instead of their name, only "undefined undefined" was there; these changes should fix this.
Previous:
<img width="1340" alt="Screenshot 2023-02-21 at 6 59 03 PM" src="https://user-images.githubusercontent.com/88568615/220485927-ee39857d-c197-4c98-8e00-4d55ec0f1c5d.png">
With New Changes:
<img width="1331" alt="Screenshot 2023-02-21 at 6 58 00 PM" src="https://user-images.githubusercontent.com/88568615/220485818-977e04ec-1d7a-477b-a24a-66dc495b21c0.png">
