### PR TITLE
Fixed Delete Employees

### DIFF
--- a/frontend/src/components/Modal/ConfirmationModal.tsx
+++ b/frontend/src/components/Modal/ConfirmationModal.tsx
@@ -13,13 +13,19 @@ type ConfirmationProps = {
   open: boolean;
   rider?: Rider;
   onClose: () => void;
-  employeeId?: string 
-  role?: string
+  employeeId?: string;
+  role?: string;
 };
 
-const ConfirmationModal = ({ open, rider, onClose, employeeId, role }: ConfirmationProps) => {
+const ConfirmationModal = ({
+  open,
+  rider,
+  onClose,
+  employeeId,
+  role,
+}: ConfirmationProps) => {
   const { refreshRiders } = useRiders();
-  const {refreshDrivers, refreshAdmins} = useEmployees()
+  const { refreshDrivers, refreshAdmins } = useEmployees();
   const { withDefaults } = useReq();
   const history = useHistory();
   const { showToast } = useToast(); // do this
@@ -30,7 +36,7 @@ const ConfirmationModal = ({ open, rider, onClose, employeeId, role }: Confirmat
 
   const studentDelete = () => {
     // If admin and driver, need to update corresponding driver schema's 'admin' attribute
-    if (role==='admin'){ 
+    if (role === 'admin') {
       fetch(
         `/api/admins/${employeeId ? employeeId : ''}`,
         withDefaults({
@@ -43,8 +49,7 @@ const ConfirmationModal = ({ open, rider, onClose, employeeId, role }: Confirmat
           showToast('The admin has been deleted.', ToastStatus.SUCCESS);
           closeModal();
         });
-    }
-    else if (role==='driver'){
+    } else if (role === 'driver') {
       fetch(
         `/api/drivers/${employeeId ? employeeId : ''}`,
         withDefaults({
@@ -59,7 +64,7 @@ const ConfirmationModal = ({ open, rider, onClose, employeeId, role }: Confirmat
         });
     }
     // Update both driver and admin dbs
-    else if (role==='both'){
+    else if (role === 'both') {
       fetch(
         `/api/drivers/${employeeId ? employeeId : ''}`,
         withDefaults({
@@ -73,8 +78,7 @@ const ConfirmationModal = ({ open, rider, onClose, employeeId, role }: Confirmat
           showToast('The employee has been deleted.', ToastStatus.SUCCESS);
           closeModal();
         });
-    }
-    else {
+    } else {
       fetch(
         `/api/riders/${!rider ? '' : rider.id}`,
         withDefaults({

--- a/frontend/src/components/Modal/ConfirmationModal.tsx
+++ b/frontend/src/components/Modal/ConfirmationModal.tsx
@@ -48,8 +48,7 @@ const ConfirmationModal = ({
       .then(refreshFunc)
       .then(() => {
         history.push(
-          `/${userGroup}`
-          // `/admins/${userType === 'rider' ? 'students' : 'employees'}`
+          `/${userType === 'rider' ? 'riders' : 'employees'}`
         );
         showToast(`The ${userType} has been deleted.`, ToastStatus.SUCCESS);
         closeModal();

--- a/frontend/src/components/Modal/ConfirmationModal.tsx
+++ b/frontend/src/components/Modal/ConfirmationModal.tsx
@@ -47,9 +47,7 @@ const ConfirmationModal = ({
     )
       .then(refreshFunc)
       .then(() => {
-        history.push(
-          `/${userType === 'rider' ? 'riders' : 'employees'}`
-        );
+        history.push(`/${userType === 'rider' ? 'riders' : 'employees'}`);
         showToast(`The ${userType} has been deleted.`, ToastStatus.SUCCESS);
         closeModal();
       });

--- a/frontend/src/components/UserDetail/EmployeeDetail.tsx
+++ b/frontend/src/components/UserDetail/EmployeeDetail.tsx
@@ -157,7 +157,7 @@ const EmployeeDetail = () => {
     findEmployee(drivers, admins, employeeId)
   );
   const pathArr = location.pathname.split('/');
-  const userType = pathArr[1];
+  const userType = pathArr[2];
 
   const [rides, setRides] = useState<Ride[]>([]);
   const [rideCount, setRideCount] = useState(-1);
@@ -202,20 +202,19 @@ const EmployeeDetail = () => {
               phone: driver.phoneNumber,
             });
           });
+        fetch(`/api/drivers/${employeeId}/stats`, withDefaults())
+          .then((res) => res.json())
+          .then((data) => {
+            if (!data.err) {
+              setRideCount(Math.floor(data.rides));
+              setWorkingHours(Math.floor(data.workingHours));
+            }
+          });
       }
     }
     fetch(`/api/rides?type=past&driver=${employeeId}`, withDefaults())
       .then((res) => res.json())
       .then(({ data }) => setRides(data.sort(compRides)));
-
-    fetch(`/api/drivers/${employeeId}/stats`, withDefaults())
-      .then((res) => res.json())
-      .then((data) => {
-        if (!data.err) {
-          setRideCount(Math.floor(data.rides));
-          setWorkingHours(Math.floor(data.workingHours));
-        }
-      });
     setEmployee(findEmployee(drivers, admins, employeeId));
   }, [admins, drivers, employeeId, withDefaults, userType]);
 

--- a/frontend/src/components/UserDetail/UserDetail.tsx
+++ b/frontend/src/components/UserDetail/UserDetail.tsx
@@ -177,7 +177,7 @@ const UserDetail = ({
               open={confirmationModalisOpen}
               rider={rider}
               onClose={closeConfirmationModal}
-              employeeId = {employee ? employee.id : ''}
+              employeeId={employee ? employee.id : ''}
               role={role}
             />
           </div>

--- a/frontend/src/components/UserDetail/UserDetail.tsx
+++ b/frontend/src/components/UserDetail/UserDetail.tsx
@@ -175,10 +175,9 @@ const UserDetail = ({
             </button>
             <ConfirmationModal
               open={confirmationModalisOpen}
-              rider={rider}
+              user={employee ? employee : rider!}
               onClose={closeConfirmationModal}
-              employeeId={employee ? employee.id : ''}
-              role={role}
+              role={role} // Specifies Admin Role, undefined if rider
             />
           </div>
         </div>

--- a/frontend/src/components/UserDetail/UserDetail.tsx
+++ b/frontend/src/components/UserDetail/UserDetail.tsx
@@ -177,6 +177,8 @@ const UserDetail = ({
               open={confirmationModalisOpen}
               rider={rider}
               onClose={closeConfirmationModal}
+              employeeId = {employee ? employee.id : ''}
+              role={role}
             />
           </div>
         </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -44,6 +44,12 @@ export type Employee = {
   startDate?: string;
 };
 
+export type User = {
+  id: string;
+  firstName: string;
+  lastName: string;
+};
+
 export type ObjectType = {
   [x: string]: any;
 };


### PR DESCRIPTION
### Summary <!-- Required -->

Prior to these changes, when trying to delete an employee on the admin side, the networks requests would just use the ConfirmationModal Component that was designed to only delete rider users. So this PR adjusted the ConfirmationModal component to account for if an employee is being deleted (i.e. an admin or a driver), and calls the proper Delete request.

### Test Plan <!-- Required -->

Manual UI testing

### Notes <!-- Optional -->

Currently, in our user schema, if someone is a driver and an admin, they are treated as separate objects in the driver db and the admin db with different ids -- there is not relation between them besides the admin attribute in the driver object being set to true. Because of this, if someone who is an admin and a driver is being deleted, I only deleted their driver user and kept their admin user.

Also, if an admin is deleted who is also a driver, their 'admin' attribute in their driver db object needs to be updated to false, but the difficulty comes in retrieving the "driver" id. This is why I think there may need to be a future schema change for our db that links 2 users who are a driver and an admin. Perhaps some sort of association table may need to be implemented.

[Trello Card](https://trello.com/c/PJx5Hhyh/445-delete-employees-is-currently-not-working)
