### PR TITLE
Fix Data Population in the Backend

### DIFF
--- a/frontend/src/components/AuthManager/AuthManager.tsx
+++ b/frontend/src/components/AuthManager/AuthManager.tsx
@@ -101,13 +101,10 @@ const AuthManager = () => {
     return googleAuth({
       flow: 'implicit',
       onSuccess: async (tokenResponse: TokenResponse) => {
-        const userInfo = await fetch(
-          'https://www.googleapis.com/oauth2/v2/userinfo',
-          {
-            method: 'GET',
-            headers: { Authorization: `Bearer ${tokenResponse.access_token}` },
-          }
-        )
+        await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${tokenResponse.access_token}` },
+        })
           .then((res) => res.json())
           .then((userInfo) => signIn(isAdmin, userInfo));
       },

--- a/server/src/router/common.ts
+++ b/server/src/router/common.ts
@@ -10,15 +10,15 @@ export function getById(
   table: string,
   callback?: (value: any) => void
 ) {
-  model.get(id || '', (err, data) => {
+  model.get(id || '', async (err, data) => {
     if (err) {
       res.status(err.statusCode || 500).send({ err: err.message });
     } else if (!data) {
       res.status(400).send({ err: `id not found in ${table}` });
     } else if (callback) {
-      callback(data.toJSON());
+      callback((await data.populate()).toJSON());
     } else {
-      res.status(200).send({ data: data.toJSON() });
+      res.status(200).send({ data: (await data.populate()).toJSON() });
     }
   });
 }
@@ -33,15 +33,15 @@ export function batchGet(
   if (!keys.length) {
     res.send({ data: [] });
   } else {
-    model.batchGet(keys, (err, data) => {
+    model.batchGet(keys, async (err, data) => {
       if (err) {
         res.status(err.statusCode || 500).send({ err: err.message });
       } else if (!data) {
         res.status(400).send({ err: `items not found in ${table}` });
       } else if (callback) {
-        callback(data.toJSON());
+        callback((await data.populate()).toJSON());
       } else {
-        res.status(200).send({ data: data.toJSON() });
+        res.status(200).send({ data: (await data.populate()).toJSON() });
       }
     });
   }
@@ -53,15 +53,15 @@ export function getAll(
   table: string,
   callback?: (value: any) => void
 ) {
-  model.scan().exec((err, data) => {
+  model.scan().exec(async (err, data) => {
     if (err) {
       res.status(err.statusCode || 500).send({ err: err.message });
     } else if (!data) {
       res.status(400).send({ err: `items not found in ${table}` });
     } else if (callback) {
-      callback(data.toJSON());
+      callback((await data.populate()).toJSON());
     } else {
-      res.status(200).send({ data: data.toJSON() });
+      res.status(200).send({ data: (await data.populate()).toJSON() });
     }
   });
 }
@@ -71,15 +71,16 @@ export function create(
   document: Document,
   callback?: (value: any) => void
 ) {
-  document.save((err, data) => {
+  document.save(async (err, data) => {
     if (err) {
       res.status(err.statusCode || 500).send({ err: err.message });
     } else if (!data) {
       res.status(400).send({ err: 'error when saving document' });
     } else if (callback) {
-      callback(data.toJSON());
+      console.log(await data.populate());
+      callback((await data.populate()).toJSON());
     } else {
-      res.status(200).send({ data: data.toJSON() });
+      res.status(200).send({ data: (await data.populate()).toJSON() });
     }
   });
 }
@@ -92,15 +93,15 @@ export function update(
   table: string,
   callback?: (value: any) => void
 ) {
-  model.update(key, operation, (err, data) => {
+  model.update(key, operation, async (err, data) => {
     if (err) {
       res.status(err.statusCode || 500).send({ err: err.message });
     } else if (!data) {
       res.status(400).send({ err: `id not found in ${table}` });
     } else if (callback) {
-      callback(data.toJSON());
+      callback((await data.populate()).toJSON());
     } else {
-      res.status(200).send({ data: data.toJSON() });
+      res.status(200).send({ data: (await data.populate()).toJSON() });
     }
   });
 }
@@ -118,15 +119,15 @@ export function conditionalUpdate(
     key,
     operation,
     { condition, return: 'document' },
-    (err, data) => {
+    async (err, data) => {
       if (err) {
         res.status(err.statusCode || 500).send({ err: err.message });
       } else if (!data) {
         res.status(400).send({ err: `id not found in ${table}` });
       } else if (callback) {
-        callback(data.toJSON());
+        callback((await data.populate()).toJSON());
       } else {
-        res.status(200).send({ data: data.toJSON() });
+        res.status(200).send({ data: (await data.populate()).toJSON() });
       }
     }
   );
@@ -159,13 +160,13 @@ export function query(
   model
     .query(condition)
     .using(index)
-    .exec((err: any, data: any) => {
+    .exec(async (err: any, data: any) => {
       if (err) {
         res.status(err.statusCode || 500).send({ err: err.message });
       } else if (callback) {
-        callback(data.toJSON());
+        callback((await data.populate()).toJSON());
       } else {
-        res.status(200).send({ data: data.toJSON() });
+        res.status(200).send({ data: (await data.populate()).toJSON() });
       }
     });
 }
@@ -176,15 +177,15 @@ export function scan(
   condition: Condition,
   callback?: (value: any) => void
 ) {
-  model.scan(condition).exec((err, data) => {
+  model.scan(condition).exec(async (err, data) => {
     if (err) {
       res.status(err.statusCode || 500).send({ err: err.message });
     } else if (!data) {
       res.status(400).send({ err: 'error when scanning table' });
     } else if (callback) {
-      callback(data.toJSON());
+      callback((await data.populate()).toJSON());
     } else {
-      res.status(200).send({ data: data.toJSON() });
+      res.status(200).send({ data: (await data.populate()).toJSON() });
     }
   });
 }

--- a/server/src/router/common.ts
+++ b/server/src/router/common.ts
@@ -77,7 +77,6 @@ export function create(
     } else if (!data) {
       res.status(400).send({ err: 'error when saving document' });
     } else if (callback) {
-      console.log(await data.populate());
       callback((await data.populate()).toJSON());
     } else {
       res.status(200).send({ data: (await data.populate()).toJSON() });

--- a/server/src/router/ride.ts
+++ b/server/src/router/ride.ts
@@ -196,8 +196,8 @@ router.put('/:id', validateUser('User'), (req, res) => {
     const { rider, driver } = ride;
     if (
       res.locals.user.userType === UserType.ADMIN ||
-      res.locals.user.id == rider ||
-      (driver && res.locals.user.id === driver)
+      res.locals.user.id == rider.id ||
+      (driver && res.locals.user.id === driver.id)
     ) {
       db.update(res, Ride, { id }, body, tableName, async (doc) => {
         const ride = doc;


### PR DESCRIPTION
### Summary

Added `.populate()` in the backend to replace document references with actual documents. This follows good practices to prevent duplication of data across the database.

For reference, `populate` converts objects like this
`
{ ride: "some id",
driver: "some id"
}
` to `
{
ride: "some id"
driver: {firstName:"some name", lastName:"some name",...}
`

This eradicates the need to fetch Objects in the Tables by Id on the frontend.

This also fixes multiple bugs on the frontend, including rider name not showing up when added an unscheduled ride is added.

### Test Plan
Now we are getting all the information about the rider and not just rider's id
<img width="633" alt="image" src="https://user-images.githubusercontent.com/80096811/221532350-fa9652f3-7012-4cab-8c20-828ca1c7d95f.png">