### PR TITLE
Test Workflow Fix

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,5 +1,5 @@
 name: CI Test
-on: push
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ jobs:
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
       PUBLIC_VAPID_KEY: ${{ secrets.PUBLIC_VAPID_KEY }}
       PRIVATE_VAPID_KEY: ${{ secrets.PRIVATE_VAPID_KEY }}
-      WEB_PUSH_CONTACT: ${{ secrets.WEB_PUSH_CONTACT }}
+      WEB_PUSH_CONTACT: '${{ secrets.WEB_PUSH_CONTACT }}'
       IOS_DRIVER_ARN: ${{ secrets.IOS_DRIVER_ARN }}
       IOS_RIDER_ARN: ${{ secrets.IOS_RIDER_ARN }}
       ANDROID_ARN: ${{ secrets.ANDROID_ARN }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,5 +1,5 @@
 name: CI Test
-on: pull_request
+on: push
 
 jobs:
   build:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ jobs:
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
       PUBLIC_VAPID_KEY: ${{ secrets.PUBLIC_VAPID_KEY }}
       PRIVATE_VAPID_KEY: ${{ secrets.PRIVATE_VAPID_KEY }}
-      WEB_PUSH_CONTACT: mailto:carriagedti@gmail.com
+      WEB_PUSH_CONTACT: ${{ secrets.WEB_PUSH_CONTACT }}
       IOS_DRIVER_ARN: ${{ secrets.IOS_DRIVER_ARN }}
       IOS_RIDER_ARN: ${{ secrets.IOS_RIDER_ARN }}
       ANDROID_ARN: ${{ secrets.ANDROID_ARN }}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25697,7 +25697,7 @@
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/webpack": {
       "version": "4.41.31",
@@ -31380,7 +31380,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -36657,7 +36657,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -38638,13 +38638,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
-    "type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "optional": true,
-      "peer": true
-    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -39320,7 +39313,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "binary-extensions": {
           "version": "1.13.1",

--- a/server/package.json
+++ b/server/package.json
@@ -37,7 +37,7 @@
     "dev": "nodemon --exec \"ts-node\" src/app.ts",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
     "type-check": "../node_modules/.bin/tsc --project tsconfig.json --pretty --noEmit",
-    "test": "cross-env NODE_ENV=test mocha -r ts-node/register tests/**/*.ts --exit",
+    "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit",
     "test:watch": "cross-env NODE_ENV=test nodemon --watch . --ext ts --exec \"mocha -r ts-node/register tests/**/*.ts\""
   },
   "repository": {

--- a/server/tests/locations.test.ts
+++ b/server/tests/locations.test.ts
@@ -23,9 +23,7 @@ describe('Locations', () => {
     });
   });
 
-  after(async () => {
-    await clearDB();
-  });
+  after(clearDB);
 
   describe('GET /api/locations', () => {
     it('should return 200 OK', async () => {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This diff fixes two issues with running Mocha tests on Github Actions.

First, glob behavior is different on Windows vs UNIX systems when they are not surrounded by quotes. This causes execution on Windows to succeed but the (probably Ubuntu) CI vm to fail to execute our mocha tests.

Also, in our `Location` test suite we want to clear our DB after we run the suite. We can simply pass our promise into the `after` function to achieve this, rather than wrapping our db call in yet another promise.

### Test Plan <!-- Required -->

Server tests pass (`npm run test`) on both local and CI.

### Notes <!-- Optional -->

Our `test:watch` command may also need a quotes fix for the glob pattern -- this needs to be tested by a dev on MacOS.