### PR TITLE
correctly filter past/upcoming rides for rider

### DIFF
--- a/frontend/src/pages/Rider/Schedule.tsx
+++ b/frontend/src/pages/Rider/Schedule.tsx
@@ -17,7 +17,10 @@ import styles from './page.module.css';
 
 const Schedule = () => {
   const componentMounted = useRef(true);
-  const [rides, setRides] = useState<Ride[]>();
+  const now = new Date().toISOString();
+  const [rides, setRides] = useState<Ride[]>([]);
+  const [currRides, setCurrRides] = useState<Ride[]>([]);
+  const [pastRides, setPastRides] = useState<Ride[]>([]);
   const { id, user } = useContext(AuthContext);
   const { withDefaults } = useReq();
   document.title = 'Schedule - Carriage';
@@ -33,7 +36,16 @@ const Schedule = () => {
     return () => {
       componentMounted.current = false;
     };
-  }, [refreshRides]);
+  }, [refreshRides, rides]);
+
+  useEffect(() => {
+    setPastRides((prev) =>
+      prev.concat(rides?.filter((ride) => ride.endTime < now) || [])
+    );
+    setCurrRides((prev) =>
+      prev.concat(rides?.filter((ride) => ride.endTime >= now) || [])
+    );
+  }, [rides]);
 
   return (
     <main id="main">
@@ -47,10 +59,10 @@ const Schedule = () => {
       {rides && rides.length > 0 && (
         <>
           <Collapsible title={'Your Upcoming Rides'}>
-            <RiderScheduleTable data={rides} isPast={false} />
+            <RiderScheduleTable data={currRides} isPast={false} />
           </Collapsible>
           <Collapsible title={'Your Past Rides'}>
-            <RiderScheduleTable data={rides} isPast={true} />
+            <RiderScheduleTable data={pastRides} isPast={false} />
           </Collapsible>
         </>
       )}

--- a/frontend/src/pages/Rider/Schedule.tsx
+++ b/frontend/src/pages/Rider/Schedule.tsx
@@ -32,20 +32,16 @@ const Schedule = () => {
 
   useEffect(() => {
     refreshRides();
-
+    setPastRides((prev) =>
+      prev.concat(rides.filter((ride) => ride.endTime < now) || [])
+    );
+    setCurrRides((prev) =>
+      prev.concat(rides.filter((ride) => ride.endTime >= now) || [])
+    );
     return () => {
       componentMounted.current = false;
     };
   }, [refreshRides, rides]);
-
-  useEffect(() => {
-    setPastRides((prev) =>
-      prev.concat(rides?.filter((ride) => ride.endTime < now) || [])
-    );
-    setCurrRides((prev) =>
-      prev.concat(rides?.filter((ride) => ride.endTime >= now) || [])
-    );
-  }, [rides]);
 
   return (
     <main id="main">


### PR DESCRIPTION
### Summary <!-- Required -->
There was an issue with the rider aspect of web where past rides would not filter correctly and would still be displayed in the "Your Upcoming Rides" tab. These changes should fix this.

### Notes <!-- Optional -->
There seems to be an issue with the isPast condition when filtering rides between Schedule.tsx and RiderScheduleTable.tsx. It is not correctly filtering rides that have come to pass. I'm not exactly sure why this is happening, but I wanted to implement this fix so we could correctly filter rides and come back to this after implementing testing.

