### PR TITLE
Fix tsconfig include

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
     "web-push": "^3.4.4"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "start": "node build/app.js",
     "dev": "nodemon --exec \"ts-node\" src/app.ts",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",

--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
     "start": "node build/app.js",
     "dev": "nodemon --exec \"ts-node\" src/app.ts",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
-    "type-check": "../node_modules/.bin/tsc --project tsconfig.json --pretty --noEmit",
+    "type-check": "tsc --pretty --noEmit",
     "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 10000",
     "test:watch": "cross-env NODE_ENV=test nodemon --watch . --ext ts --exec \"mocha -r ts-node/register tests/**/*.ts\""
   },

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["tests"]
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,6 +6,6 @@
     "allowJs": true,
     "module": "commonjs"
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "exclude": ["node_modules"]
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,11 +6,6 @@
     "allowJs": true,
     "module": "commonjs"
   },
-  "include": [
-    "src",
-    "tests"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### Summary <!-- Required -->

When adding a test framework to the server, we mistakenly included the tests folder into the `include` section of the tsconfig.

This causes problems because it nests our `src` folder into the build folder, rather than flattening it out. This causes relative paths to break, resulting in the frontend not being served.

We also do not need to compile the tests because they are not run in prod.
### Test Plan <!-- Required -->

Ensure `npm run test` within `server` folder still works.

Ensure `npm build` within `server` folder builds `build` folder without `src` subfolder.

<!-- Provide screenshots or point out the additional unit tests -->

