### PR TITLE
Add CD workflow to push container to Docker Hub

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - enoch/dockerhub
+      - main
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,0 +1,25 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - master
+      - enoch/dockerhub
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: dticarriage/carriage-service:latest

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - enoch/dockerhub
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - main
+      - enoch/dockerhub
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -21,9 +21,10 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          context: .
           push: true
           build-args: |
-            'REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}'
-            'REACT_APP_PUBLIC_VAPID_KEY=${{ secrets.REACT_APP_PUBLIC_VAPID_KEY }}'
-            'REACT_APP_ENCRYPTION_KEY=${{ secrets.REACT_APP_ENCRYPTION_KEY }}'
+            REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}
+            REACT_APP_PUBLIC_VAPID_KEY=${{ secrets.REACT_APP_PUBLIC_VAPID_KEY }}
+            REACT_APP_ENCRYPTION_KEY=${{ secrets.REACT_APP_ENCRYPTION_KEY }}
           tags: dticarriage/carriage-service:latest

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -22,4 +22,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          build-args: |
+            'REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}'
+            'REACT_APP_PUBLIC_VAPID_KEY=${{ secrets.REACT_APP_PUBLIC_VAPID_KEY }}'
+            'REACT_APP_ENCRYPTION_KEY=${{ secrets.REACT_APP_ENCRYPTION_KEY }}'
           tags: dticarriage/carriage-service:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ FROM node:16-alpine
 # Create a directory for the app
 WORKDIR /app
 
+# Read build-time environment variables
+ARG REACT_APP_CLIENT_ID
+ENV REACT_APP_CLIENT_ID ${REACT_APP_CLIENT_ID}
+ARG REACT_APP_PUBLIC_VAPID_KEY
+ENV REACT_APP_PUBLIC_VAPID_KEY ${REACT_APP_PUBLIC_VAPID_KEY}
+ARG REACT_APP_ENCRYPTION_KEY
+ENV REACT_APP_ENCRYPTION_KEY ${REACT_APP_ENCRYPTION_KEY}
+
 # Copy package.jsons first to install
 COPY package.json package-lock.json /app/
 COPY frontend/package.json frontend/package-lock.json /app/frontend/

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,11 +6,6 @@
     "allowJs": true,
     "module": "commonjs"
   },
-  "include": [
-    "src",
-    "tests"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### Summary <!-- Required -->

When a PR gets merged into master (or main, if we ever switch), we want to build our Docker container and push to the Docker Hub registry.

This diff implements a CD workflow that does that.

### Test Plan <!-- Required -->

The workflow has been run successfully.

The new Docker image shows up on the Docker Hub website.

I can pull and run the container locally:
![image](https://user-images.githubusercontent.com/3837473/223230559-5740a0b9-5491-4c13-84cc-f4d3e8bad5aa.png)

The web app is served correctly by the container, and I am able to log in and perform various actions.

### Notes <!-- Optional -->

Whenever we end up switching to the `main` branch, the reference to `master` will no longer be required and should be removed.
