### PR TITLE
Runtime secrets refactoring

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -10,8 +10,8 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -20,7 +20,6 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
-          context: .
           push: true
           build-args: |
             REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - enoch/dockerhub
+      - main
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,0 +1,25 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - master
+      - enoch/dockerhub
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: dticarriage/carriage-service:latest

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - enoch/dockerhub
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - main
+      - enoch/dockerhub
 
 jobs:
   push_to_registry:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -21,9 +21,10 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
+          context: .
           push: true
           build-args: |
-            'REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}'
-            'REACT_APP_PUBLIC_VAPID_KEY=${{ secrets.REACT_APP_PUBLIC_VAPID_KEY }}'
-            'REACT_APP_ENCRYPTION_KEY=${{ secrets.REACT_APP_ENCRYPTION_KEY }}'
+            REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}
+            REACT_APP_PUBLIC_VAPID_KEY=${{ secrets.REACT_APP_PUBLIC_VAPID_KEY }}
+            REACT_APP_ENCRYPTION_KEY=${{ secrets.REACT_APP_ENCRYPTION_KEY }}
           tags: dticarriage/carriage-service:latest

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -22,4 +22,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          build-args: |
+            'REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}'
+            'REACT_APP_PUBLIC_VAPID_KEY=${{ secrets.REACT_APP_PUBLIC_VAPID_KEY }}'
+            'REACT_APP_ENCRYPTION_KEY=${{ secrets.REACT_APP_ENCRYPTION_KEY }}'
           tags: dticarriage/carriage-service:latest

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build the image
-        run: docker-compose build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build Docker image
+        uses: docker/build-push-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:16-alpine
 # Create a directory for the app
 WORKDIR /app
 
+# Set production environment for node
+ENV NODE_ENV=production
+
 # Read build-time environment variables
 ARG REACT_APP_CLIENT_ID
 ENV REACT_APP_CLIENT_ID ${REACT_APP_CLIENT_ID}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ FROM node:16-alpine
 # Create a directory for the app
 WORKDIR /app
 
+# Read build-time environment variables
+ARG REACT_APP_CLIENT_ID
+ENV REACT_APP_CLIENT_ID ${REACT_APP_CLIENT_ID}
+ARG REACT_APP_PUBLIC_VAPID_KEY
+ENV REACT_APP_PUBLIC_VAPID_KEY ${REACT_APP_PUBLIC_VAPID_KEY}
+ARG REACT_APP_ENCRYPTION_KEY
+ENV REACT_APP_ENCRYPTION_KEY ${REACT_APP_ENCRYPTION_KEY}
+
 # Copy package.jsons first to install
 COPY package.json package-lock.json /app/
 COPY frontend/package.json frontend/package-lock.json /app/frontend/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,26 +2,14 @@ version: '3'
 
 services:
   carriage:
-    build: .
-    environment:
-      - NODE_ENV=production
-      - DEBUG=True
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - JWT_SECRET=${JWT_SECRET}
-      - PUBLIC_VAPID_KEY=${PUBLIC_VAPID_KEY}
-      - PRIVATE_VAPID_KEY=${PRIVATE_VAPID_KEY}
-      - WEB_PUSH_CONTACT=${WEB_PUSH_CONTACT}
-      - IOS_DRIVER_ARN=${IOS_DRIVER_ARN}
-      - IOS_RIDER_ARN=${IOS_RIDER_ARN}
-      - ANDROID_ARN=${ANDROID_ARN}
-      - HOSTNAME=${HOSTNAME}
-      - USE_HOSTNAME=${USE_HOSTNAME}
-      - REACT_APP_CLIENT_ID=${REACT_APP_CLIENT_ID}
-      - REACT_APP_PUBLIC_VAPID_KEY=${REACT_APP_PUBLIC_VAPID_KEY}
-      - REACT_APP_ENCRYPTION_KEY=${REACT_APP_ENCRYPTION_KEY}
-      - DOMAIN=${DOMAIN}
+    build:
+      context: .
+      args:
+        - REACT_APP_CLIENT_ID=${REACT_APP_CLIENT_ID}
+        - REACT_APP_PUBLIC_VAPID_KEY=${REACT_APP_PUBLIC_VAPID_KEY}
+        - REACT_APP_ENCRYPTION_KEY=${REACT_APP_ENCRYPTION_KEY}
     ports:
       - '3001:3001'
     image: dticarriage/carriage-service:latest
     restart: always
+    env_file: .env


### PR DESCRIPTION
### Summary <!-- Required -->

Previously, our `docker-compose.yml` loaded up various environment variables and made them available to both the build process and the container. Some of these env vars are secrets and are not necessary to the build process, and so we would not like to embed them into our image, which poses as a potential security vulnerability.

We made a change to the Dockerfile in #417 which now expects REACT_APP env vars in the form of build_args. This new change updates the `docker-compose.yml` to supply those args.

This change now also moves these secrets to be loaded from an .env file (so we don't need to explicitly specify each one) into the container using the `env_file` option.

### Test Plan <!-- Required -->

`docker-compose build` and `docker-compose up` works as expected.

### Notes <!-- Optional -->

Right now React-related env vars are still loaded up during build time, but we may actually want to look for a solution that can load during runtime instead.

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
