### PR TITLE
fixed voiceover on modal

### DIFF
--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -81,6 +81,7 @@ const Modal = ({
                       className={styles.closeBtn}
                       id={'close'}
                       onClick={onClose}
+                      aria-label={currentTitle as string}
                     >
                       <img alt="close" src={close} />
                     </button>


### PR DESCRIPTION
### Summary <!-- Required -->

When modal is announced, the screenreader properly reads aloud the modal title, instead of 'close button'

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Opened all the modals and ensured the title was read properly
