### PR TITLE
fixing npm run test:watch on mac

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
     "type-check": "tsc --pretty --noEmit",
     "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 10000",
-    "test:watch": "cross-env NODE_ENV=test nodemon --watch . --ext ts --exec \"mocha -r ts-node/register tests/**/*.ts\""
+    "test:watch": "cross-env NODE_ENV=test ./node_modules/nodemon/bin/nodemon.js --watch . --exec 'mocha -r ts-node/register \"tests/**/*.ts\" || true'"
   },
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
     "type-check": "tsc --pretty --noEmit",
     "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 10000",
-    "test:watch": "cross-env NODE_ENV=test ./node_modules/nodemon/bin/nodemon.js --watch . --exec 'mocha -r ts-node/register \"tests/**/*.ts\" || true'"
+    "test:watch": "cross-env NODE_ENV=test ./node_modules/nodemon/bin/nodemon.js --watch . --exec 'mocha -r ts-node/register \"tests/**/*.ts\" --timeout 10000' --ext ts"
   },
   "repository": {
     "type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
     "type-check": "tsc --pretty --noEmit",
     "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 10000",
-    "test:watch": "cross-env NODE_ENV=test ./node_modules/nodemon/bin/nodemon.js --watch . --exec 'mocha -r ts-node/register \"tests/**/*.ts\" --timeout 10000' --ext ts"
+    "test:watch": "cross-env NODE_ENV=test nodemon --watch . --exec 'mocha -r ts-node/register \"tests/**/*.ts\" --timeout 10000' --ext ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary <!-- Required -->

fix the npm run test:watch command on Macs, saving on test files. specifically .ts files, should rerun the tests now

### Test Plan <!-- Required -->

use npm run test:watch and see tests run and rerun on saves