### PR TITLE
Stats endpoints Testing

### DIFF
--- a/server/tests/stats.test.ts
+++ b/server/tests/stats.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+import { expect } from 'chai';
+import { StatsType } from '../src/models/stats';
+import authorize from './utils/auth';
+import app from '../src/app';
+import moment from 'moment';
+
+type EditStatsType = {
+  year?: string;
+  monthDay?: string;
+  dayCount?: number;
+  dayNoShow?: number;
+  dayCancel?: number;
+  nightCount?: number;
+  nightNoShow?: number;
+  nightCancel?: number;
+  drivers?: {
+    [name: string]: number;
+  };
+};
+
+// Generate 2 random dates formatted "YYYY-MM-DD"
+const generate_get_dates = (): [string, string] => {
+  const latestDate = moment(); // current date and time
+  const earliestDate = moment().subtract(1, 'year'); // one year ago
+
+  const randomDate1 = moment(
+    earliestDate.valueOf() +
+      Math.random() * (latestDate.valueOf() - earliestDate.valueOf())
+  ).format('YYYY-MM-DD');
+
+  const randomDate2 = moment(
+    earliestDate.valueOf() +
+      Math.random() * (latestDate.valueOf() - earliestDate.valueOf())
+  ).format('YYYY-MM-DD');
+
+  let to_date: string;
+  let from_date: string;
+  if (moment(randomDate1).isAfter(randomDate2)) {
+    to_date = randomDate1;
+    from_date = randomDate2;
+  } else {
+    from_date = randomDate1;
+    to_date = randomDate2;
+  }
+
+  return [from_date, to_date];
+};
+
+// Generate Random edit dates and content to update (Arrays are same size)
+const generate_edit_dates = (): [[string], [EditStatsType]] => {
+  return [['date1'], [{}]];
+};
+
+describe('Stats Tests', () => {
+  let adminToken: string;
+  const [from_date, to_date] = generate_get_dates();
+
+  before(async () => {
+    adminToken = await authorize('Admin', {
+      firstName: 'Test-Admin',
+      lastName: 'Test-Admin',
+      phoneNumber: '1111111111',
+      email: 'test-admin@cornell.edu',
+    });
+  });
+
+  describe('GET /api/stats', () => {
+    it('Fetch the stats in the range of specified dates', async () => {
+      const res = await request(app)
+        .get(`/api/stats?from=${from_date}&to=${to_date ? to_date : ''}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8');
+      const days =
+        moment(to_date as string, 'YYYY-MM-DD').diff(
+          moment(from_date as string, 'YYYY-MM-DD'),
+          'days'
+        ) + 1;
+      expect(res.body)
+        .to.be.an('array')
+        .and.to.have.lengthOf(to_date ? days : 1);
+    });
+  });
+
+  describe('PUT /api/stats', () => {
+    it('Update Specified Dates', async () => {
+      
+    });
+  });
+});


### PR DESCRIPTION
### Summary <!-- Required -->

Added Tests for the Stats endpoints (GET and PUT requests)

This pull request regarding the backend testing. [Trello Ticket](https://trello.com/c/M6ZlZQgD/467-stats-endpoint)

### Test Plan <!-- Required -->
Test Cases Pass

### Notes <!-- Optional -->
To Test the GET /api/stats, I generated random from/to dates as query parameters. The response should be stats between the specified dates. I utilized property based testing to ensure the length of the stats elements in the response is equivalent to the number of dates between the randomly generated from_date and to_date. 

To Test the PUT /api/stats, I generated random values for the StatsType and updated the corresponding date. I then tested to make sure that the response of the PUT request (which is the Stats object that was updated), matches the randomly generated data. The helper function to generate the random request data and valid data only only generates 1 at a time and may be generalized to multiple dates in the future, as the PUT request does support updating multiple dates at once.

Finally, I tested the PUT and GET requests but generated a random date to update the stats, and calling the GET request on that same date, and ensuring that the response of the GET request matched the randomly generated stats that was sent with the PUT request.

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->
Minor changes to Notion API Documentation as request/response formats did not align with code.
