### PR TITLE
Stats endpoints Testing

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -37,7 +37,7 @@
     "dev": "nodemon --exec \"ts-node\" src/app.ts",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
     "type-check": "tsc --pretty --noEmit",
-    "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 10000",
+    "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 20000",
     "test:watch": "cross-env NODE_ENV=test nodemon --watch . --ext ts --exec \"mocha -r ts-node/register tests/**/*.ts\""
   },
   "repository": {

--- a/server/package.json
+++ b/server/package.json
@@ -37,8 +37,8 @@
     "dev": "nodemon --exec \"ts-node\" src/app.ts",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
     "type-check": "tsc --pretty --noEmit",
-    "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 20000",
-    "test:watch": "cross-env NODE_ENV=test nodemon --watch . --ext ts --exec \"mocha -r ts-node/register tests/**/*.ts\""
+    "test": "cross-env NODE_ENV=test mocha -r ts-node/register \"tests/**/*.ts\" --exit --timeout 10000",
+    "test:watch": "cross-env NODE_ENV=test nodemon --watch . --exec 'mocha -r ts-node/register \"tests/**/*.ts\" --timeout 10000' --ext ts"
   },
   "repository": {
     "type": "git",

--- a/server/src/router/stats.ts
+++ b/server/src/router/stats.ts
@@ -90,7 +90,7 @@ function statsFromDates(dates: string[], res: Response, download: boolean) {
     // day = 12am to 5:00pm
     const dayStart = dateMoment.toISOString();
     const dayEnd = dateMoment.add(17, 'hours').toISOString();
-    // night = 5:01pm to 11:59:59pm
+    // night = 5:01pm to 11:59:59pm.
     const nightStart = moment(dayEnd).add(1, 'seconds').toISOString();
     const nightEnd = moment(currDate as string)
       .endOf('day')

--- a/server/tests/stats.test.ts
+++ b/server/tests/stats.test.ts
@@ -108,7 +108,7 @@ describe('Stats Tests', () => {
   });
 
   after(clearDB);
-  
+
   describe('GET /api/stats', () => {
     it('Fetch the stats in the range of specified dates', async () => {
       const res = await request(app)

--- a/server/tests/stats.test.ts
+++ b/server/tests/stats.test.ts
@@ -145,7 +145,7 @@ describe('Stats Tests', () => {
   describe('PUT & GET of same date', () => {
     it('Updates stats at a random Date and GETs Data at that date', async () => {
       const statsData = generateEditDatesData();
-      // Format Date 'YYYY-MM-DD'; Assume statsData just contains 1 date.
+      // Format Date 'YYYY-MM-DD'; Assume statsData just contains 1 date
       const from = `${statsData[0].year}-${statsData[0].monthDay.substring(
         0,
         2

--- a/server/tests/stats.test.ts
+++ b/server/tests/stats.test.ts
@@ -145,7 +145,7 @@ describe('Stats Tests', () => {
   describe('PUT & GET of same date', () => {
     it('Updates stats at a random Date and GETs Data at that date', async () => {
       const statsData = generateEditDatesData();
-      // Format Date 'YYYY-MM-DD'; Assume statsData just contains 1 date
+      // Format Date 'YYYY-MM-DD'; Assume statsData just contains 1 date.
       const from = `${statsData[0].year}-${statsData[0].monthDay.substring(
         0,
         2

--- a/server/tests/stats.test.ts
+++ b/server/tests/stats.test.ts
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { clearDB } from './utils/db';
 
 // Generate 2 random dates formatted "YYYY-MM-DD"
-const generate_get_dates = (): [string, string] => {
+const generateGetDates = (): [string, string] => {
   const latestDate = moment(); // current date and time
   const earliestDate = moment().subtract(1, 'year'); // one year ago
 
@@ -21,21 +21,21 @@ const generate_get_dates = (): [string, string] => {
       Math.random() * (latestDate.valueOf() - earliestDate.valueOf())
   ).format('YYYY-MM-DD');
 
-  let to_date: string;
-  let from_date: string;
+  let toDate: string;
+  let fromDate: string;
   if (moment(randomDate1).isAfter(randomDate2)) {
-    to_date = randomDate1;
-    from_date = randomDate2;
+    toDate = randomDate1;
+    fromDate = randomDate2;
   } else {
-    from_date = randomDate1;
-    to_date = randomDate2;
+    fromDate = randomDate1;
+    toDate = randomDate2;
   }
 
-  return [from_date, to_date];
+  return [fromDate, toDate];
 };
 
 //Generate n=1 random dates and corresposnding StatsType Data to be updated
-const generate_edit_dates_data = (): StatsType[] => {
+const generateEditDatesData = (): StatsType[] => {
   const n = 1; // Adjust parameter for more data values
   const latestDate = moment(); // current date and time
   const earliestDate = moment().subtract(1, 'year'); // one year ago
@@ -73,7 +73,7 @@ const generate_edit_dates_data = (): StatsType[] => {
 
 // Formats Stats Type Data to proper request structure
 // Currently Assumes stats contains 1 element
-const format_edit_dates_request = (stats: StatsType[]) => {
+const formatEditDatesRequest = (stats: StatsType[]) => {
   const updatedStats: StatsType = stats[0];
   const formatDate = `${updatedStats.monthDay.substring(
     0,
@@ -96,7 +96,7 @@ const format_edit_dates_request = (stats: StatsType[]) => {
 
 describe('Stats Tests', () => {
   let adminToken: string;
-  const [from_date, to_date] = generate_get_dates();
+  const [fromDate, toDate] = generateGetDates();
 
   before(async () => {
     adminToken = await authorize('Admin', {
@@ -110,25 +110,25 @@ describe('Stats Tests', () => {
   describe('GET /api/stats', () => {
     it('Fetch the stats in the range of specified dates', async () => {
       const res = await request(app)
-        .get(`/api/stats?from=${from_date}&to=${to_date ? to_date : ''}`)
+        .get(`/api/stats?from=${fromDate}&to=${toDate ? toDate : ''}`)
         .set('Authorization', `Bearer ${adminToken}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8');
       const days =
-        moment(to_date as string, 'YYYY-MM-DD').diff(
-          moment(from_date as string, 'YYYY-MM-DD'),
+        moment(toDate as string, 'YYYY-MM-DD').diff(
+          moment(fromDate as string, 'YYYY-MM-DD'),
           'days'
         ) + 1;
       expect(res.body)
         .to.be.an('array')
-        .and.to.have.lengthOf(to_date ? days : 1);
+        .and.to.have.lengthOf(toDate ? days : 1);
     });
   });
 
   describe('PUT /api/stats', () => {
     it('Update Date', async () => {
-      const statsData = generate_edit_dates_data();
-      const requestBody = format_edit_dates_request(statsData);
+      const statsData = generateEditDatesData();
+      const requestBody = formatEditDatesRequest(statsData);
       const res = await request(app)
         .put('/api/stats')
         .send(requestBody)
@@ -144,14 +144,14 @@ describe('Stats Tests', () => {
 
   describe('PUT & GET of same date', () => {
     it('Updates stats at a random Date and GETs Data at that date', async () => {
-      const statsData = generate_edit_dates_data();
+      const statsData = generateEditDatesData();
       // Format Date 'YYYY-MM-DD'; Assume statsData just contains 1 date.
       const from = `${statsData[0].year}-${statsData[0].monthDay.substring(
         0,
         2
       )}-${statsData[0].monthDay.substring(2, 4)}`;
       const to = null;
-      const requestBody = format_edit_dates_request(statsData);
+      const requestBody = formatEditDatesRequest(statsData);
       await request(app)
         .put('/api/stats')
         .send(requestBody)

--- a/server/tests/stats.test.ts
+++ b/server/tests/stats.test.ts
@@ -107,6 +107,8 @@ describe('Stats Tests', () => {
     });
   });
 
+  after(clearDB);
+  
   describe('GET /api/stats', () => {
     it('Fetch the stats in the range of specified dates', async () => {
       const res = await request(app)
@@ -140,8 +142,6 @@ describe('Stats Tests', () => {
     });
   });
 
-  after(clearDB);
-
   describe('PUT & GET of same date', () => {
     it('Updates stats at a random Date and GETs Data at that date', async () => {
       const statsData = generateEditDatesData();
@@ -166,6 +166,5 @@ describe('Stats Tests', () => {
         .expect('Content-Type', 'application/json; charset=utf-8');
       expect(getRes.body[0]).to.deep.equal(statsData[0]);
     });
-    after(clearDB);
   });
 });

--- a/server/tests/stats.test.ts
+++ b/server/tests/stats.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+import { expect } from 'chai';
+import { StatsType } from '../src/models/stats';
+import authorize from './utils/auth';
+import app from '../src/app';
+import moment from 'moment';
+
+type EditStatsType = {
+  year?: string;
+  monthDay?: string;
+  dayCount?: number;
+  dayNoShow?: number;
+  dayCancel?: number;
+  nightCount?: number;
+  nightNoShow?: number;
+  nightCancel?: number;
+  drivers?: {
+    [name: string]: number;
+  };
+};
+
+// Generate 2 random dates formatted "YYYY-MM-DD"
+const generate_get_dates = (): [string, string] => {
+  const latestDate = moment(); // current date and time
+  const earliestDate = moment().subtract(1, 'year'); // one year ago
+
+  const randomDate1 = moment(
+    earliestDate.valueOf() +
+      Math.random() * (latestDate.valueOf() - earliestDate.valueOf())
+  ).format('YYYY-MM-DD');
+
+  const randomDate2 = moment(
+    earliestDate.valueOf() +
+      Math.random() * (latestDate.valueOf() - earliestDate.valueOf())
+  ).format('YYYY-MM-DD');
+
+  let to_date: string;
+  let from_date: string;
+  if (moment(randomDate1).isAfter(randomDate2)) {
+    to_date = randomDate1;
+    from_date = randomDate2;
+  } else {
+    from_date = randomDate1;
+    to_date = randomDate2;
+  }
+
+  return [from_date, to_date];
+};
+
+// Generate Random edit dates and content to update (Arrays are same size)
+const generate_edit_dates = (): [[string], [EditStatsType]] => {
+  return [['date1'], [{}]];
+};
+
+describe('Stats Tests', () => {
+  let adminToken: string;
+  const [from_date, to_date] = generate_get_dates();
+
+  before(async () => {
+    adminToken = await authorize('Admin', {
+      firstName: 'Test-Admin',
+      lastName: 'Test-Admin',
+      phoneNumber: '1111111111',
+      email: 'test-admin@cornell.edu',
+    });
+  });
+
+  describe('GET /api/stats', () => {
+    it('Fetch the stats in the range of specified dates', async () => {
+      const res = await request(app)
+        .get(`/api/stats?from=${from_date}&to=${to_date ? to_date : ''}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8');
+      const days =
+        moment(to_date as string, 'YYYY-MM-DD').diff(
+          moment(from_date as string, 'YYYY-MM-DD'),
+          'days'
+        ) + 1;
+      expect(res.body)
+        .to.be.an('array')
+        .and.to.have.lengthOf(to_date ? days : 1);
+    });
+  });
+
+  describe('PUT /api/stats', () => {
+    it('Update Specified Dates', async () => {
+      
+    });
+  });
+});


### PR DESCRIPTION
### Summary <!-- Required -->

Added Tests for the Stats endpoints (GET and PUT requests)

This pull request regarding the backend testing. [Trello Ticket](https://trello.com/c/M6ZlZQgD/467-stats-endpoint)

### Test Plan <!-- Required -->
Test Cases Pass

### Notes <!-- Optional -->
To Test the GET /api/stats, I generated random from/to dates as query parameters. The response should be stats between the specified dates. I utilized property based testing to ensure the length of the stats elements in the response is equivalent to the number of dates between the randomly generated from_date and to_date. 

To Test the PUT /api/stats, I generated random values for the StatsType and updated the corresponding date. I then tested to make sure that the response of the PUT request (which is the Stats object that was updated), matches the randomly generated data. The helper function to generate the random request data and valid data only only generates 1 at a time and may be generalized to multiple dates in the future, as the PUT request does support updating multiple dates at once.

Finally, I tested the PUT and GET requests but generated a random date to update the stats, and calling the GET request on that same date, and ensuring that the response of the GET request matched the randomly generated stats that was sent with the PUT request.

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->
Minor changes to Notion API Documentation as request/response formats did not align with code.
