### PR TITLE
Auth Refactor

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@react-aria/utils": "^3.15.0",
-        "@react-oauth/google": "^0.4.0",
+        "@react-oauth/google": "^0.9.0",
         "@types/crypto-js": "^4.1.1",
         "@types/jest": "^29.2.2",
         "@types/node": "^18.11.9",
@@ -3191,9 +3191,9 @@
       }
     },
     "node_modules/@react-oauth/google": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.4.0.tgz",
-      "integrity": "sha512-2QxxrKbXXH8bwHSefB56sBgsKs7Bq3Pvv8tVmGJuINGefECsssIUKidTDm5P55T4CV99sCX/GUfxs3l2Ntxo8Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.9.0.tgz",
+      "integrity": "sha512-iq9I6A4uwZezU/BixqLM6UET6an559ufC4Nh0lEIeIaKC3TJRvcPNWCjjHny56yAhgdT6ivUicLIvEoiSMjnmg==",
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
@@ -25000,9 +25000,9 @@
       }
     },
     "@react-oauth/google": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.4.0.tgz",
-      "integrity": "sha512-2QxxrKbXXH8bwHSefB56sBgsKs7Bq3Pvv8tVmGJuINGefECsssIUKidTDm5P55T4CV99sCX/GUfxs3l2Ntxo8Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.9.0.tgz",
+      "integrity": "sha512-iq9I6A4uwZezU/BixqLM6UET6an559ufC4Nh0lEIeIaKC3TJRvcPNWCjjHny56yAhgdT6ivUicLIvEoiSMjnmg==",
       "requires": {}
     },
     "@react-stately/utils": {
@@ -25793,7 +25793,7 @@
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
+      "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/webpack": {
       "version": "4.41.31",
@@ -31476,7 +31476,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -36753,7 +36753,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -38734,13 +38734,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
-    "type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "optional": true,
-      "peer": true
-    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -39416,7 +39409,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "binary-extensions": {
           "version": "1.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@react-aria/utils": "^3.15.0",
-    "@react-oauth/google": "^0.4.0",
+    "@react-oauth/google": "^0.9.0",
     "@types/crypto-js": "^4.1.1",
     "@types/jest": "^29.2.2",
     "@types/node": "^18.11.9",

--- a/frontend/src/components/AuthManager/AuthManager.tsx
+++ b/frontend/src/components/AuthManager/AuthManager.tsx
@@ -99,20 +99,15 @@ const AuthManager = () => {
 
   function GoogleAuth(isAdmin: boolean) {
     return googleAuth({
-      flow: 'implicit',
-      onSuccess: async (tokenResponse: TokenResponse) => {
-        await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
-          method: 'GET',
-          headers: { Authorization: `Bearer ${tokenResponse.access_token}` },
-        })
-          .then((res) => res.json())
-          .then((userInfo) => signIn(isAdmin, userInfo));
+      flow: 'auth-code',
+      onSuccess: async (res) => {
+        signIn(isAdmin, res.code);
       },
       onError: (errorResponse: any) => console.error(errorResponse),
     });
   }
 
-  function signIn(isAdmin: boolean, userInfo: any) {
+  function signIn(isAdmin: boolean, code: string) {
     const userType = isAdmin ? 'Admin' : 'Rider';
     const table = `${userType}s`;
     const localUserType = localStorage.getItem('userType');
@@ -123,7 +118,7 @@ const AuthManager = () => {
           withDefaults({
             method: 'POST',
             body: JSON.stringify({
-              userInfo,
+              code,
               table,
             }),
           })

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -94,20 +94,20 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
-      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3028,20 +3028,20 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
-      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -20,3 +20,8 @@ export const snsValues = {
   ios_rider: process.env.IOS_RIDER_ARN!,
   android: process.env.ANDROID_ARN!,
 };
+
+export const oauthValues = {
+  client_id: process.env.OAUTH_CLIENT_ID,
+  client_secret: process.env.OAUTH_CLIENT_SECRET,
+};

--- a/server/src/router/auth.ts
+++ b/server/src/router/auth.ts
@@ -94,7 +94,6 @@ async function getIdToken(client: OAuth2Client, code: string) {
 router.post('/', async (req, res) => {
   const { code, table } = req.body;
   try {
-    console.log(req.headers);
     const client = new OAuth2Client({
       clientId: oauthValues.client_id,
       clientSecret: oauthValues.client_secret,


### PR DESCRIPTION
### Summary <!-- Required -->

At some point in the code base, the server was changed to just trust what the client identifies its email as, which is insecure.

This diff uses the `auth-code` OAuth flow to authenticate the client.

This is a smaller-effort change than the original Firebase idea, but it ultimately addresses the same problem without bundling firebase into both the frontend and backend.

### Test Plan <!-- Required -->

Login works with Docker container.

### Notes <!-- Optional -->

The auth client will still prefer the `idToken` form of identification if it is passed in the body. It will ignore the `code` value if `idToken` exists. This feature is important for mobile clients which have a better time getting `idToken`s than web.

### Breaking Changes  <!-- Optional -->

Login currently does NOT work when using a proxy when developing locally for the frontend and backend. This is because the `auth-code` process involves a `redirectURL` which must match the origin where the code was generated. However, due to the proxy, the origin is faked and thus auth fails.

The solution is to disable the proxy and set the backend URL explicitly OR run the docker container which actually runs them on the same port.