### PR TITLE
making button and tags more descriptive

### DIFF
--- a/frontend/src/components/RequestRideModal/RequestRideModal.tsx
+++ b/frontend/src/components/RequestRideModal/RequestRideModal.tsx
@@ -71,7 +71,7 @@ const RequestRideModal = ({
               : () => openCreateOrEditModal('EDIT_REGULAR')
           }
         >
-          Edit
+          Edit Ride
         </Button>
       )}
       {ride && ride.recurring && (

--- a/frontend/src/components/TableComponents/TableComponents.tsx
+++ b/frontend/src/components/TableComponents/TableComponents.tsx
@@ -36,6 +36,7 @@ type RowProps = {
   data: Row;
   colSizes: number[];
   header?: boolean;
+  smallTag?: boolean;
   groupStart?: number;
   className?: string;
   onClick?: () => void;
@@ -52,6 +53,7 @@ export const Row = ({
   data,
   colSizes,
   header,
+  smallTag = true,
   groupStart,
   className,
   onClick,
@@ -71,7 +73,7 @@ export const Row = ({
         return <Cell key={idx} data={cell} />;
       }
       const { data: cData, tag } = cell;
-      return <Cell key={idx} data={cData} tag={tag} smallTag={true} />;
+      return <Cell key={idx} data={cData} tag={tag} smallTag={smallTag} />;
     });
 
   if (!header && groupStart) {

--- a/frontend/src/components/UserTables/RiderRidesTable.tsx
+++ b/frontend/src/components/UserTables/RiderRidesTable.tsx
@@ -14,7 +14,7 @@ type RiderRidesTableProps = {
 
 const RiderRidesTable = ({ rides, isPast }: RiderRidesTableProps) => {
   const [deleteOpen, setDeleteOpen] = useState(-1);
-  const colSizes = [1, 1, 1, 1, 1, 1];
+  const colSizes = [1, 1, 1, 1.25, 1, 1];
   const headers = [
     'Time',
     'Pickup Location',
@@ -80,7 +80,7 @@ const RiderRidesTable = ({ rides, isPast }: RiderRidesTableProps) => {
             data: (
               <p>
                 {recurringDays}
-                <span className={styles.bold}> {recurringDateRange}</span>
+                <span className={styles.highlight}> {recurringDateRange}</span>
               </p>
             ),
           };
@@ -142,7 +142,11 @@ const RiderRidesTable = ({ rides, isPast }: RiderRidesTableProps) => {
                 onClose={onClose}
                 deleting={true}
               />
-              <Row data={unscheduledRideData} colSizes={colSizes} />
+              <Row
+                data={unscheduledRideData}
+                smallTag={false}
+                colSizes={colSizes}
+              />
             </span>
           );
         })}

--- a/frontend/src/components/UserTables/table.module.css
+++ b/frontend/src/components/UserTables/table.module.css
@@ -86,6 +86,10 @@
   font-weight: bold;
 }
 
+.highlight {
+  background-color: rgb(177, 255, 177);
+}
+
 .gray {
   color: #616161;
 }


### PR DESCRIPTION
### Summary <!-- Required -->

We needed to make the edit button more descriptive because it opened a different modal depending on whether the ride was recurring or not. In addition, we wanted to make the dates of the recurring rides more prevalent as well as the tags becoming more descriptive of the location of the pickup and dropoff locations.

