### PR TITLE
Fix Deployment Issues

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -38,7 +38,7 @@ jobs:
             ANDROID_ARN=${{ secrets.ANDROID_ARN }},
             HOSTNAME=${{ secrets.HOSTNAME }},
             USE_HOSTNAME=${{ secrets.USE_HOSTNAME }},
-            OAUTH_CLIENT_ID=${{ secrets.OAUTH_CLIENT_ID }}
+            OAUTH_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}
             OAUTH_CLIENT_SECRET=${{ secrets.OAUTH_CLIENT_SECRET }}
             REACT_APP_SERVER_URL=${{ secrets.REACT_APP_SERVER_URL }},
             REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }},


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes the env variable that is used while deploying. `OAUTH_CLIENT_ID` is the same as `REACT_APP_CLIENT_ID`, but one is for the server and the other for the frontend.