### PR TITLE
Add alt text to back button

### DIFF
--- a/frontend/src/components/UserDetail/EmployeeDetail.tsx
+++ b/frontend/src/components/UserDetail/EmployeeDetail.tsx
@@ -145,7 +145,7 @@ const Header = () => {
         }}
         className={styles.header}
       >
-        <img className={styles.chevronLeft} src={chevronLeft} />
+        <img className={styles.chevronLeft} src={chevronLeft} alt="Employees" />
         Employees
       </Link>
     </div>

--- a/frontend/src/components/UserDetail/EmployeeDetail.tsx
+++ b/frontend/src/components/UserDetail/EmployeeDetail.tsx
@@ -162,6 +162,15 @@ const EmployeeDetail = () => {
   const [rideCount, setRideCount] = useState(-1);
   const [workingHours, setWorkingHours] = useState(-1);
 
+  /**
+   * Compares ride [a] with ride [b] based on their start time. Returns a
+   * negative number if [a] starts before [b], a positive number if [a] starts
+   * after [b], and 0 otherwise
+   *
+   * @param a the first ride to compare
+   * @param b the second ride to compare
+   * @returns -1, 1, or 0 if the start time of [a] is before, after, or the same as [b]
+   */
   const compRides = (a: Ride, b: Ride) => {
     const x = new Date(a.startTime);
     const y = new Date(b.startTime);

--- a/frontend/src/components/UserDetail/EmployeeDetail.tsx
+++ b/frontend/src/components/UserDetail/EmployeeDetail.tsx
@@ -145,7 +145,11 @@ const Header = () => {
         }}
         className={styles.header}
       >
-        <img className={styles.chevronLeft} src={chevronLeft} alt="Back to Employees List" />
+        <img
+          className={styles.chevronLeft}
+          src={chevronLeft}
+          alt="Back to Employees List"
+        />
         Employees
       </Link>
     </div>

--- a/frontend/src/components/UserDetail/EmployeeDetail.tsx
+++ b/frontend/src/components/UserDetail/EmployeeDetail.tsx
@@ -145,7 +145,7 @@ const Header = () => {
         }}
         className={styles.header}
       >
-        <img className={styles.chevronLeft} src={chevronLeft} alt="Employees" />
+        <img className={styles.chevronLeft} src={chevronLeft} alt="Back to Employees List" />
         Employees
       </Link>
     </div>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds alt text to the chevron button that takes users from the employee details page back to the employees list page.

![image](https://github.com/cornell-dti/carriage-web/assets/45516888/4d4afc3c-0f71-4241-bf33-0876312c93d8)

- [x] Added alt text to the chevron image for the back button
- [x] Documented the compRides() function 

### Test Plan <!-- Required -->
Testing was conducted by using inspect element on the back button on the employee details webpage and verifying that the image has the `alt` attribute with the appropriate text:

<img width="666" alt="Screenshot 2023-10-01 at 11 28 16 PM" src="https://github.com/cornell-dti/carriage-web/assets/45516888/b869963c-9324-4df0-8419-afce54be124a">