### PR TITLE
Add alt-text and aria labels to the sidebar

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -84,12 +84,13 @@ const Sidebar = ({ type, children }: SidebarProps) => {
         <div className={styles.menuItems}>
           {menuItems.map(({ path, icon, caption }) => (
             <div key={path} className={styles.sidebarLinks}>
-              <p className={styles.caption}>
+              <p className={styles.caption} id={path}>
                 <Link
                   key={path}
                   onClick={() => setSelected(path)}
                   className={styles.icon}
                   to={path}
+                  aria-labelledby={path}
                 >
                   <div
                     className={
@@ -102,7 +103,7 @@ const Sidebar = ({ type, children }: SidebarProps) => {
                       href={path}
                       aria-current={path === selected ? 'page' : undefined}
                     ></a>
-                    <img alt={''} src={icon} />
+                    <img alt={`Go to ${caption}`} src={icon} />
                   </div>
                 </Link>
                 {caption}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds alt text and aria labels to the links on the sidebar

- [x] add alt text to icon images
- [x] add aria-labels to link elements

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Testing was conducted by using inspect element on the sidebar and verifying that the icons have the alt attribute with the appropriate text and the links reference the correct paragraph caption:

Example of appropriate alt text:
<img width="609" alt="Screenshot 2023-10-03 at 4 02 16 PM" src="https://github.com/cornell-dti/carriage-web/assets/45516888/a6b7724f-4331-4295-b73b-8fce8f5ef5d1">

Example of appropriate aria label:
<img width="479" alt="Screenshot 2023-10-03 at 4 02 47 PM" src="https://github.com/cornell-dti/carriage-web/assets/45516888/ea377b1c-87bd-4b25-89c0-b440a980f124">
