### PR TITLE
Calendar Modal Fix - Multiple Selections Display

### DIFF
--- a/frontend/src/components/MiniCal/MiniCal.tsx
+++ b/frontend/src/components/MiniCal/MiniCal.tsx
@@ -33,6 +33,7 @@ const Icon = () => (
 
 const MiniCal = () => {
   const { curDate, setCurDate } = useDate();
+  const datePickerRef = React.useRef<any>(null);
 
   const updateDate = (d: Date) => {
     setCurDate(d);
@@ -82,7 +83,9 @@ const MiniCal = () => {
     <div className={styles.root}>
       <DatePicker
         adjustDateOnChange
+        ref={datePickerRef}
         selected={curDate}
+        shouldCloseOnSelect={false}
         onChange={updateDate}
         closeOnScroll={true}
         dateFormat="MMM dd, yyyy"
@@ -103,7 +106,11 @@ const MiniCal = () => {
               <button
                 className={cn(styles.btn2, { [styles.active]: isToday(date) })}
                 onClick={() => {
-                  updateDate(new Date());
+                  const today = new Date();
+                  if (datePickerRef.current) {
+                    datePickerRef.current.setSelected(today);
+                  }
+                  updateDate(today);
                   pseudoScroll();
                 }}
               >
@@ -117,6 +124,9 @@ const MiniCal = () => {
                 onClick={() => {
                   const tomorrow = new Date();
                   tomorrow.setDate(new Date().getDate() + 1);
+                  if (datePickerRef.current) {
+                    datePickerRef.current.setSelected(tomorrow);
+                  }
                   updateDate(tomorrow);
                   pseudoScroll();
                 }}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request fixes the bug displayed on the Mini Calendar when selecting dates using the Today and Tomorrow buttons. Also addresses closing the modal when a date is selected (ideally not the intended behavior)

- [x] implemented useRef state to address the change to the DatePicker component
- [x] fixed closing modal when date is selected 

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Choose dates using the Today and Tomorrow buttons when other dates are selected to identify behavior

### Notes <!-- Optional -->

#### Initial behavior
https://github.com/cornell-dti/carriage-web/assets/106533812/42d24d92-6707-4826-a15d-0d1a078a475f

#### Fixed behavior
https://github.com/cornell-dti/carriage-web/assets/106533812/456a4b64-319a-497e-acf6-734a78e01117



<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->
None
<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
