### PR TITLE
Display employee photos in cards

### DIFF
--- a/frontend/src/components/EmployeeCards/EmployeeCards.tsx
+++ b/frontend/src/components/EmployeeCards/EmployeeCards.tsx
@@ -156,27 +156,26 @@ const EmployeeCard = ({
 const EmployeeCards = () => {
   const { admins, drivers } = useEmployees();
 
-  const allEmployees = [...admins, ...drivers];
-  const adminIds = new Set(admins.map((admin) => admin.id));
-  const filteredEmployees = allEmployees.filter((employee: Employee) => {
-    // if not admin (means driver), check if another admin is representing this driver
-    if (employee['isDriver'] == undefined) return !adminIds.has(employee.id);
-    return true;
+  const employees: Record<string, DriverType | AdminType> = {};
+  [...admins, ...drivers].forEach((employee) => {
+    employees[employee.id] = { ...employees[employee.id], ...employee };
   });
 
-  filteredEmployees.sort((a: Employee, b: Employee) => {
-    if (a.firstName < b.firstName) {
-      return -1;
+  const sortedEmployees = Object.values(employees).sort(
+    (a: Employee, b: Employee) => {
+      if (a.firstName < b.firstName) {
+        return -1;
+      }
+      if (a.firstName > b.firstName) {
+        return 1;
+      }
+      return 0;
     }
-    if (a.firstName > b.firstName) {
-      return 1;
-    }
-    return 0;
-  });
+  );
 
   return (
     <div className={styles.cardsContainer}>
-      {filteredEmployees.map((employee) => (
+      {sortedEmployees.map((employee) => (
         <EmployeeCard key={employee.id} id={employee.id} employee={employee} />
       ))}
     </div>


### PR DESCRIPTION
### Summary <!-- Required -->

This allows photos to be visible. The issue was that admin accounts supported photos but no admin account in the db actually has a photo. However the corresponding driver accounts do have photos.

This PR "combines" the two employee account objects so that you only need a `photoLink` in either your admin or driver account for it to display in your card.

Note that this will use the driver `photoLink` if both are provided. In the future we should aim to restructure the DB so that this kind of ambiguity isn't possible.

### Test Plan <!-- Required -->
![image](https://github.com/cornell-dti/carriage-web/assets/3837473/9fdbedf8-d9ef-4677-81a5-3e6b41a24ed6)


<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

Note that this will use the driver `photoLink` if both are provided. In the future we should aim to restructure the DB so that this kind of ambiguity isn't possible.

<!--- List any important or subtle points, future considerations, or other items of note. -->
