### PR TITLE
implement employee filters (admins/drivers)

### DIFF
--- a/frontend/src/components/EmployeeCards/employeecards.module.css
+++ b/frontend/src/components/EmployeeCards/employeecards.module.css
@@ -13,3 +13,11 @@
   color: inherit;
   display: inline-block;
 }
+
+.filtersContainer {
+  margin-left: 2rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 1rem;
+}

--- a/frontend/src/components/FormElements/formelements.module.css
+++ b/frontend/src/components/FormElements/formelements.module.css
@@ -48,9 +48,10 @@
 }
 
 .primaryBtn {
-  background-color: black;
   color: white;
-  border: none;
+  background-color: black;
+  border: 0.063rem solid #000000;
+  box-sizing: border-box;
 }
 .primaryBtn:focus {
   box-shadow: 0 0 0 3px #0075db;

--- a/server/src/models/driver.ts
+++ b/server/src/models/driver.ts
@@ -21,7 +21,7 @@ export type DriverType = {
   firstName: string;
   lastName: string;
   availability: AvailabilityType;
-  vehicle: VehicleType;
+  vehicle?: VehicleType;
   phoneNumber: string;
   startDate: string;
   email: string;


### PR DESCRIPTION
### Summary <!-- Required -->

This diff adds a two-button role filter to the Employees page.

For example, selecting "Drivers" will filter the results such that only Driver accounts are shown. Selecting both shows all employees, as does selecting none (the default state).

### Test Plan <!-- Required -->

<details><summary>None Selected</summary>

![img](https://i.imgur.com/STAnGnD.png)

</details>
<details><summary>One Selected</summary>

![img](https://i.imgur.com/j0DKyDI.png)

</details>
<details><summary>Both Selected</summary>

![img](https://i.imgur.com/iALD41q.png)

</details>






### Notes <!-- Optional -->

The described button behavior is pretty arbitrary imo, and can be changed in the future.
