### PR TITLE
Rename accessibility enums

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -58,6 +58,7 @@ export type ObjectType = {
 export type Vehicle = VehicleType;
 
 export enum Tag {
+  EAST = 'east',
   CENTRAL = 'central',
   NORTH = 'north',
   WEST = 'west',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,7 +8,7 @@ import { VehicleType } from '../../../server/src/models/vehicle';
 export type Rider = RiderType;
 
 export enum Accessibility {
-  NONE = '',
+  NONE = 'None',
   ASSISTANT = 'Assistant',
   CRUTCHES = 'Crutches',
   WHEELCHAIR = 'Wheelchair',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,7 +15,7 @@ export enum Accessibility {
   MOTOR_SCOOTER = 'Motorized Scooter',
   KNEE_SCOOTER = 'Knee Scooter',
   LOW_VISION = 'Low Vision/Blind',
-  SERVICE_ANIMALS = 'Service Animals',
+  SERVICE_ANIMALS = 'Service Animal',
   OTHER = 'Other',
 }
 

--- a/server/src/models/location.ts
+++ b/server/src/models/location.ts
@@ -3,6 +3,7 @@ import { formatAddress, isAddress } from '../util';
 import defaultModelConfig from '../util/modelConfig';
 
 export enum Tag {
+  EAST = 'east',
   WEST = 'west',
   CENTRAL = 'central',
   NORTH = 'north',

--- a/server/src/models/rider.ts
+++ b/server/src/models/rider.ts
@@ -11,7 +11,7 @@ export enum Accessibility {
   MOTOR_SCOOTER = 'Motorized Scooter',
   KNEE_SCOOTER = 'Knee Scooter',
   LOW_VISION = 'Low Vision/Blind',
-  SERVICE_ANIMALS = 'Service Animals',
+  SERVICE_ANIMALS = 'Service Animal',
   OTHER = 'Other',
 }
 


### PR DESCRIPTION
We update `accessibility` to include `None` and `tag` to include `east`.