### PR TITLE
Unscheduled rides are now expanded by default

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.8.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "tsc": "../node_modules/.bin/tsc --noEmit false",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",

--- a/frontend/src/components/Collapsible/Collapsible.tsx
+++ b/frontend/src/components/Collapsible/Collapsible.tsx
@@ -8,7 +8,7 @@ type CollapsibleSection = {
 };
 
 const Collapsible = ({ title, children }: CollapsibleSection) => {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(true); // Every Collapsible component will be expanded by default
   const icon = expanded ? down : up;
 
   const handleKeywordKeyPress = (e: React.KeyboardEvent) => {

--- a/frontend/src/components/Collapsible/Collapsible.tsx
+++ b/frontend/src/components/Collapsible/Collapsible.tsx
@@ -8,7 +8,7 @@ type CollapsibleSection = {
 };
 
 const Collapsible = ({ title, children }: CollapsibleSection) => {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(true);
   const icon = expanded ? down : up;
 
   const handleKeywordKeyPress = (e: React.KeyboardEvent) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@typescript-eslint/parser": "^4.31.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-promise": "^5.1.0",
-        "typescript": "^4.4.3"
+        "typescript": "^4.9.5"
       },
       "devDependencies": {
         "@babel/core": "^7.14.8",
@@ -3160,9 +3160,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5535,9 +5535,9 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@typescript-eslint/parser": "^4.31.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-promise": "^5.1.0",
-    "typescript": "^4.4.3"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request ensures that the "Unscheduled Rides" dropdown is expanded by default.

### Test Plan <!-- Required -->

<img width="1498" alt="Screen Shot 2024-03-03 at 12 06 27 AM" src="https://github.com/cornell-dti/carriage-web/assets/135656237/03477f71-d622-416c-83eb-ce0ee35c295e">

### Notes <!-- Optional -->

The "Unscheduled Rides" dropdown for every date are not independent states. For example, if I un-expand the dropdown for March 21th, and then click on March 4th, the latter's dropdown will be unexpanded instead of defaulting to its expanded state.



<img width="239" alt="Screen Shot 2024-03-03 at 12 05 55 AM" src="https://github.com/cornell-dti/carriage-web/assets/135656237/cb03deb1-a352-4a72-a472-7085dc2579fc">

*I unexpand "Unscheduled Rides" on March 21*

<img width="227" alt="Screen Shot 2024-03-03 at 12 06 03 AM" src="https://github.com/cornell-dti/carriage-web/assets/135656237/b0bdef38-363e-4860-8ff5-152aa93a21d7">

*When I go back to March 4, it remains unexpanded*