### PR TITLE
Add Needs entry to student when selecting "other"

### DIFF
--- a/frontend/src/components/Modal/RiderModalInfo.tsx
+++ b/frontend/src/components/Modal/RiderModalInfo.tsx
@@ -153,7 +153,7 @@ const RiderModalInfo = ({
               id="otherNeeds"
               name="otherNeeds"
               type="text"
-              aria-required="true"
+              placeholder='Please Specify Needs'
             ></Input>
           ) : (
             <></>

--- a/frontend/src/components/Modal/RiderModalInfo.tsx
+++ b/frontend/src/components/Modal/RiderModalInfo.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import cn from 'classnames';
 import { Button, Input, Label } from '../FormElements/FormElements';
@@ -59,11 +59,11 @@ const RiderModalInfo = ({
     setFormData({});
     setIsOpen(false);
   };
-  
+
   const localUserType = localStorage.getItem('userType');
   const isEditing = rider !== undefined;
   const isStudentEditing = isEditing && localUserType === 'Rider';
-  const [needsOption, setNeedsOption] = useState("")
+  const [needsOption, setNeedsOption] = useState('');
   return (
     <form onSubmit={handleSubmit(beforeSubmit)} className={styles.form}>
       <div className={cn(styles.inputContainer, styles.rideTime)}>
@@ -138,7 +138,7 @@ const RiderModalInfo = ({
             name="needs"
             aria-required="true"
             ref={register({ required: true })}
-            onChange = {e => setNeedsOption(e.target.value)}
+            onChange={(e) => setNeedsOption(e.target.value)}
           >
             {Object.values(Accessibility).map((value, index) => {
               return (
@@ -148,7 +148,16 @@ const RiderModalInfo = ({
               );
             })}
           </select>
-          {needsOption == "Other" ? <Input id = "otherNeeds" name = "otherNeeds" type = "text" aria-required="true"></Input> : <></>}
+          {needsOption == 'Other' ? (
+            <Input
+              id="otherNeeds"
+              name="otherNeeds"
+              type="text"
+              aria-required="true"
+            ></Input>
+          ) : (
+            <></>
+          )}
           {errors.needs?.type === 'validate' && (
             <p className={styles.error}>
               Invalid needs. You can enter 'Assistant', 'Crutches', or

--- a/frontend/src/components/Modal/RiderModalInfo.tsx
+++ b/frontend/src/components/Modal/RiderModalInfo.tsx
@@ -153,7 +153,7 @@ const RiderModalInfo = ({
               id="otherNeeds"
               name="otherNeeds"
               type="text"
-              placeholder='Please Specify Needs'
+              placeholder="Please Specify Needs"
             ></Input>
           ) : (
             <></>

--- a/frontend/src/components/Modal/RiderModalInfo.tsx
+++ b/frontend/src/components/Modal/RiderModalInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { useForm } from 'react-hook-form';
 import cn from 'classnames';
 import { Button, Input, Label } from '../FormElements/FormElements';
@@ -59,11 +59,11 @@ const RiderModalInfo = ({
     setFormData({});
     setIsOpen(false);
   };
-
+  
   const localUserType = localStorage.getItem('userType');
   const isEditing = rider !== undefined;
   const isStudentEditing = isEditing && localUserType === 'Rider';
-
+  const [needsOption, setNeedsOption] = useState("")
   return (
     <form onSubmit={handleSubmit(beforeSubmit)} className={styles.form}>
       <div className={cn(styles.inputContainer, styles.rideTime)}>
@@ -138,6 +138,7 @@ const RiderModalInfo = ({
             name="needs"
             aria-required="true"
             ref={register({ required: true })}
+            onChange = {e => setNeedsOption(e.target.value)}
           >
             {Object.values(Accessibility).map((value, index) => {
               return (
@@ -147,6 +148,7 @@ const RiderModalInfo = ({
               );
             })}
           </select>
+          {needsOption == "Other" ? <Input id = "otherNeeds" name = "otherNeeds" type = "text" aria-required="true"></Input> : <></>}
           {errors.needs?.type === 'validate' && (
             <p className={styles.error}>
               Invalid needs. You can enter 'Assistant', 'Crutches', or


### PR DESCRIPTION
### Summary

Added an input field that appears below the "Needs" drop downbox when "Other" is selected to student. It doesn't update the database and is for just appearance.

![image](https://github.com/cornell-dti/carriage-web/assets/61220757/ce4c75ba-8378-440c-b167-b3d813f7db04)
_When "Other" is not selected_

![image](https://github.com/cornell-dti/carriage-web/assets/61220757/f396c50c-0439-45f0-81fb-07e61d1b174f)
_When "Other" is selected_


Tested on different screen sizes (mobile, desktop) and no bugs have been spotted.

- [x] implemented the textbox when other is selected.

### Test Plan

No plans currently as it doesn't update the database or have any bugs.

### Notes 

### Breaking Changes  

None.
