### PR TITLE
Temp deploy fix [DO NOT MERGE]

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,9 @@ The **Rider App** branch can be found [here](https://github.com/cornell-dti/carr
 
 **Current Contributors**
 
-- Harrison Chin - Software Developer
-- Andrew Choi - Product Manager
-- Rohit Valiveti - Software Developer
-- Pratyush Sudhakar - Technical Project Manager
-- Enoch Chen - Software Developer
-- Desmond Atikpui - Software Developer
-- Stuti Gupta - Software Developer
-- Kevin Lin - Software Developer
-- Colin Wu - Software Developer
+- Stephy Chen - Product Manager
+- Desmond Atikpui - Techical Project Manager
+- Andrew Choi - Software Developer
 - Raissa Ji - Software Developer
 - Selena Liu - Software Developer
 
@@ -46,6 +40,13 @@ The **Rider App** branch can be found [here](https://github.com/cornell-dti/carr
 - Bryan Graeser - Product Manager
 - Nina Xie - Product Manager
 - Matthew Guo - Technical Project Manager
+- Stuti Gupta - Software Developer
+- Kevin Lin - Software Developer
+- Enoch Chen - Software Developer
+- Colin Wu - Software Developer
+- Harrison Chin - Software Developer
+- Rohit Valiveti - Software Developer
+- Pratyush Sudhakar - Technical Project Manager
 - Aaron Kang - Software Developer
 - Zack Ashen - Software Developer
 - Tucker Stanley - Software Developer

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "typescript": "^4.8.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "tsc": "../node_modules/.bin/tsc --noEmit false",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts build",
+    "build": "react-scripts --openssl-legacy-provider build",
     "tsc": "../node_modules/.bin/tsc --noEmit false",
     "lint": "eslint . --ext .js --ext .jsx --ext .ts --ext .tsx --fix",
     "type-check": "../node_modules/.bin/tsc --project tsconfig.json --pretty --noEmit",


### PR DESCRIPTION
### Summary
Implemented the `--openssl-legacy-provider` flag in our `start` and  `build` script to address an OpenSSL-related error encountered with newer versions of Node. This change allows our application to bypass the `ERR_OSSL_EVP_UNSUPPORTED` error, enabling compatibility with older dependencies that require legacy OpenSSL support.

### Notes
Encountered a runtime error due to OpenSSL version incompatibility. The issue arises from the stricter default settings for OpenSSL in Node.js v17 and above, affecting older dependencies:

A link to a similar issue with the outdated cryptographic dependency here 
[Issue](https://github.com/nodejs/help/issues/4115)

```plaintext
Error: error:0308010C:digital envelope routines::unsupported
...
code: 'ERR_OSSL_EVP_UNSUPPORTED'