### PR TITLE
Edit visual indicator for active vs inactive students

### DIFF
--- a/frontend/src/components/UserTables/StudentsTable.tsx
+++ b/frontend/src/components/UserTables/StudentsTable.tsx
@@ -129,7 +129,7 @@ const StudentsTable = ({ searchName }: studentTableProps) => {
             endDate
           )}`;
           const usageData = getUsageData(id);
-          const isStudentInvalid = moment().isAfter(moment(endDate)) && active;
+          const isStudentInvalid = moment().isAfter(moment(endDate)) && !active;
           const location = {
             pathname: `/riders/${r.id}`,
           };


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Edited visual indicator so that red line shows only when a user's status is inactive and their end date has passed.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
<img width="1289" alt="Screenshot 2024-03-09 at 4 01 26 PM" src="https://github.com/cornell-dti/carriage-web/assets/115762778/b8cea3b6-7c72-49ac-80c5-f902a2218abc">
Red lines only when they're inactive.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
- Some students with end dates that have passed have activity status active when it should be inactive

### Breaking Changes  <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
