### PR TITLE
Rj353/student address requirements

### DIFF
--- a/frontend/src/components/Modal/RiderModalInfo.tsx
+++ b/frontend/src/components/Modal/RiderModalInfo.tsx
@@ -165,7 +165,7 @@ const RiderModalInfo = ({
             aria-required="true"
             ref={register({
               required: true,
-              pattern: /^[a-zA-Z0-9\s,.'-]{3,}$/,
+              validate: (value) => value.trim() !== '',
             })}
           />
           {errors.address && (

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -11,28 +11,6 @@ export function createKeys(property: string, values: string[]) {
 }
 
 export function isAddress(address: string) {
-  // let parsedAddr;
-  // try {
-  //   parsedAddr = parseAddress(address);
-  // } catch {
-  //   return false;
-  // }
-  // const {
-  //   streetNumber,
-  //   streetName,
-  //   streetSuffix,
-  //   placeName,
-  //   stateName,
-  //   zipCode,
-  // } = parsedAddr;
-  // return Boolean(
-  //   streetNumber &&
-  //     streetName &&
-  //     streetSuffix &&
-  //     placeName &&
-  //     stateName &&
-  //     zipCode
-  // );
   return true;
 }
 

--- a/server/src/util/index.ts
+++ b/server/src/util/index.ts
@@ -11,28 +11,29 @@ export function createKeys(property: string, values: string[]) {
 }
 
 export function isAddress(address: string) {
-  let parsedAddr;
-  try {
-    parsedAddr = parseAddress(address);
-  } catch {
-    return false;
-  }
-  const {
-    streetNumber,
-    streetName,
-    streetSuffix,
-    placeName,
-    stateName,
-    zipCode,
-  } = parsedAddr;
-  return Boolean(
-    streetNumber &&
-      streetName &&
-      streetSuffix &&
-      placeName &&
-      stateName &&
-      zipCode
-  );
+  // let parsedAddr;
+  // try {
+  //   parsedAddr = parseAddress(address);
+  // } catch {
+  //   return false;
+  // }
+  // const {
+  //   streetNumber,
+  //   streetName,
+  //   streetSuffix,
+  //   placeName,
+  //   stateName,
+  //   zipCode,
+  // } = parsedAddr;
+  // return Boolean(
+  //   streetNumber &&
+  //     streetName &&
+  //     streetSuffix &&
+  //     placeName &&
+  //     stateName &&
+  //     zipCode
+  // );
+  return true;
 }
 
 export function formatAddress(address: string): string {
@@ -41,7 +42,11 @@ export function formatAddress(address: string): string {
     // type declaration in addresser is incorrect
     parsedAddr = parseAddress(address) as any;
   } catch {
-    parsedAddr = parseAddress(`${address}, Ithaca, NY 14850`) as any;
+    try {
+      parsedAddr = parseAddress(`${address}, Ithaca, NY 14850`) as any;
+    } catch {
+      return address;
+    }
   }
   return parsedAddr.formattedAddress;
 }


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request removes the address parsing condition within isAddress. It also removes the requirement that the input be at least 3 characters long in RiderModalInfo.tsx. Now, any address input that is not empty or spaces will be valid. This is to resolve the inconsistent add/edit behavior noted in PR #425 regarding the address field.

### Test Plan <!-- Required -->

<img width="866" alt="Screen Shot 2024-03-12 at 9 34 10 PM" src="https://github.com/cornell-dti/carriage-web/assets/135656237/c0000f76-f397-41eb-8506-13a3007ce262">

Attempting to submit an address input of just spaces will alert the error message.

<img width="868" alt="Screen Shot 2024-03-12 at 9 34 28 PM" src="https://github.com/cornell-dti/carriage-web/assets/135656237/0dd76404-f187-4dd8-9dcd-f6082313c336">

Attempting to submit an empty address input will also alert the error message.

<img width="651" alt="Screen Shot 2024-03-12 at 9 35 19 PM" src="https://github.com/cornell-dti/carriage-web/assets/135656237/5e394c2b-f25a-41a9-853b-c97cc7353340">

Previously, the input "300 Day Hall" wouldn't have worked. Now, 300 Day Hall is parsed and appended with ", Ithaca, NY 14850" to be a valid address.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
None