### PR TITLE
Changed the MiniCal component to gray out weekends and holidays

### DIFF
--- a/frontend/src/components/MiniCal/MiniCal.tsx
+++ b/frontend/src/components/MiniCal/MiniCal.tsx
@@ -6,6 +6,35 @@ import './datepicker_override.css';
 import styles from './minical.module.css';
 import { useDate } from '../../context/date';
 
+/**startDate is inclusive, endDate is exclusive */
+type Holiday = {
+  startDate: Date;
+  endDate: Date;
+  holidayName: string;
+};
+
+const holidays: Holiday[] = [
+  {
+    startDate: new Date('2024-2-24'),
+    endDate: new Date('2024-2-28'),
+    holidayName: 'Febuaray Break',
+  },
+  {
+    startDate: new Date('2024-3-30'),
+    endDate: new Date('2024-4-8'),
+    holidayName: 'Spring Break',
+  },
+];
+
+const isHoliday = (date: Date) => {
+  for (const holiday of holidays) {
+    if (holiday.startDate <= date && date < holiday.endDate) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const currentDate = new Date();
 const isToday = (date: Date) =>
   date.getDate() === currentDate.getDate() &&
@@ -77,17 +106,26 @@ const MiniCal = () => {
     window.scroll(x + 1, y);
     window.scroll(x, y);
   };
+  const isWeekday = (date: Date) => {
+    const day = date.getDay();
+    return day !== 0 && day !== 6;
+  };
+
+  const filterDate = (date: Date) => {
+    return isWeekday(date) && !isHoliday(date);
+  };
 
   return (
     <div className={styles.root}>
       <DatePicker
-        adjustDateOnChange
+        //adjustDateOnChange
         selected={curDate}
         onChange={updateDate}
         closeOnScroll={true}
         dateFormat="MMM dd, yyyy"
         showPopperArrow={false}
         customInput={<CustomInput />}
+        filterDate={filterDate}
         highlightDates={[{ 'custom--today': [new Date()] }]}
         renderCustomHeader={({
           date,

--- a/frontend/src/components/MiniCal/datepicker_override.css
+++ b/frontend/src/components/MiniCal/datepicker_override.css
@@ -69,7 +69,7 @@
 .react-datepicker__year-text--in-selecting-range,
 .react-datepicker__year-text--in-range {
   border-radius: 0.3rem;
-  background-color: #000000;
+  background-color: black;
   color: #fff;
 }
 
@@ -78,7 +78,7 @@
 .react-datepicker__quarter-text--keyboard-selected,
 .react-datepicker__year-text--keyboard-selected {
   border-radius: 0.3rem;
-  background-color: #000000;
+  background-color: rgba(0, 0, 0, 0.25);
   color: #fff;
 }
 


### PR DESCRIPTION
### Summary 

Weekends and Holidays are now grayed out in MiniCal component. You can add new holidays by adding new Holiday objects to the holidays list. 

I also changed some css styling to make it clear which day is currently selected and made it so that when you increase or decrease the month, the selected date stays the same while the highlighted date still changes. This was changed because if selected dates are automatically set by increasing or decreasing the month then it would land on disabled days like weekends or holidays.

![image](https://github.com/cornell-dti/carriage-web/assets/61220757/4c807c6d-9144-4cba-ac5a-7ce580d58b40)
_Here, 1st of May is selected_

![image](https://github.com/cornell-dti/carriage-web/assets/61220757/edb53d7d-2448-47f7-bdd6-68586bbcd4ee)
_Now, if we decrease the month to April, the selected date stays the same and the highlighted date is grayish. This was done because there might be holidays (in this case spring break) when we increase or decrease the month so I wouldn't want these dates to be selectable. Here, you can't click on 1st of April because it's in spring break._

![image](https://github.com/cornell-dti/carriage-web/assets/61220757/de938ed2-aabe-4b21-b610-3656ff14b596)
_Go back to March_

This pull request is the first step towards integrating the MiniCal component into date inputs site wide.

I have not yet integrated this changed MiniCal into a modal to replace the Input component with input = "date".

### Test Plan

I plan to integrate MiniCal into one of the modals and check if the forms are submitted correctly.

