### PR TITLE
Added snapping when scrolling the schedule on homepage.

### DIFF
--- a/frontend/src/components/Schedule/big_calendar_override.css
+++ b/frontend/src/components/Schedule/big_calendar_override.css
@@ -16,7 +16,7 @@
 
 /* other seperating timeslots */
 .rbc-day-slot .rbc-time-slot {
-  border-top: 0.063rem solid rgba(0, 0, 0, 15%); 
+  border-top: 0.063rem solid rgba(0, 0, 0, 15%);
 }
 
 /* line below drivers */
@@ -53,7 +53,7 @@
 }
 
 .rbc-today {
-  background-color:white;
+  background-color: white;
 }
 
 .rbc-header {

--- a/frontend/src/components/Schedule/big_calendar_override.css
+++ b/frontend/src/components/Schedule/big_calendar_override.css
@@ -64,8 +64,8 @@
   scroll-snap-type: both mandatory;
 }
 
-.rbc-day-slot .rbc-time-column {
-  scroll-snap-align: end;
+.rbc-time-column {
+  scroll-snap-align: start end;
 }
 
 .rbc-timeslot-group {

--- a/frontend/src/components/Schedule/big_calendar_override.css
+++ b/frontend/src/components/Schedule/big_calendar_override.css
@@ -65,7 +65,7 @@
 }
 
 .rbc-time-column {
-  scroll-snap-align: start end;
+  scroll-snap-align: end;
 }
 
 .rbc-timeslot-group {

--- a/frontend/src/components/Schedule/big_calendar_override.css
+++ b/frontend/src/components/Schedule/big_calendar_override.css
@@ -64,7 +64,7 @@
   scroll-snap-type: both mandatory;
 }
 
-.rbc-time-column {
+.rbc-day-slot .rbc-time-column {
   scroll-snap-align: end;
 }
 

--- a/frontend/src/components/Schedule/big_calendar_override.css
+++ b/frontend/src/components/Schedule/big_calendar_override.css
@@ -15,9 +15,9 @@
 }
 
 /* other seperating timeslots */
-/* .rbc-day-slot .rbc-time-slot {
+.rbc-day-slot .rbc-time-slot {
   border-top: 0.063rem solid rgba(0, 0, 0, 15%); 
-} */
+}
 
 /* line below drivers */
 .rbc-time-header-content > .rbc-row.rbc-row-resource {
@@ -64,7 +64,7 @@
   scroll-snap-type: both mandatory;
 }
 
-.rbc-time-column {
+.rbc-day-slot .rbc-time-column {
   scroll-snap-align: end;
 }
 

--- a/frontend/src/components/Schedule/big_calendar_override.css
+++ b/frontend/src/components/Schedule/big_calendar_override.css
@@ -64,7 +64,7 @@
   scroll-snap-type: both mandatory;
 }
 
-.rbc-day-slot .rbc-time-column {
+.rbc-time-column {
   scroll-snap-align: end;
 }
 

--- a/frontend/src/components/Schedule/big_calendar_override.css
+++ b/frontend/src/components/Schedule/big_calendar_override.css
@@ -53,9 +53,21 @@
 }
 
 .rbc-today {
-  background-color: white;
+  background-color:white;
 }
 
 .rbc-header {
   font-weight: 400;
+}
+
+.rbc-time-content {
+  scroll-snap-type: both mandatory;
+}
+
+.rbc-time-column {
+  scroll-snap-align: end;
+}
+
+.rbc-timeslot-group {
+  scroll-snap-align: start;
 }

--- a/frontend/src/components/Schedule/schedule.module.css
+++ b/frontend/src/components/Schedule/schedule.module.css
@@ -15,6 +15,7 @@
 .left {
   width: calc(100% - 3.125rem);
   height: 21.875rem;
+  scroll-snap-type: y mandatory;
 }
 
 .right {

--- a/frontend/src/components/Schedule/schedule.module.css
+++ b/frontend/src/components/Schedule/schedule.module.css
@@ -15,7 +15,6 @@
 .left {
   width: calc(100% - 3.125rem);
   height: 21.875rem;
-  scroll-snap-type: y mandatory;
 }
 
 .right {


### PR DESCRIPTION
### Summary 

Implemented snapping when scrolling on the schedule. The the rows are snapped on top and the columns are snapped to the end.

[screen-capture (2).webm](https://github.com/cornell-dti/carriage-web/assets/61220757/281684a6-625c-4e82-a0ea-20c2e4c91c5a)

The vertical scrolling works as expected, but there's still some weird behavior for horizontal scroll. The scroll sometimes get snapped to a portion in the middle of a cell instead of to the end. I will try to investigate the docs for scroll-snap-align more thoroughly in the future to see why.

[screen-capture (3).webm](https://github.com/cornell-dti/carriage-web/assets/61220757/67c425e5-1d7f-4749-b606-4963552feb7d)
_Some weird behavior with horizontal snapping_


This pull request is the first step towards redesigning the schedule on the home page.


### Test Plan 

I tested the scrolling on different screen sizes and it doesn't work too well on smaller screens like the Iphone, so I might have to do a media queries in the future.
