### PR TITLE
Employee Card styling

### DIFF
--- a/frontend/src/components/Card/card.module.css
+++ b/frontend/src/components/Card/card.module.css
@@ -1,7 +1,7 @@
 .card {
   display: inline-block;
   width: 17.2rem;
-  height: 23rem;
+  /* height: 23rem; */
   background-color: white;
   border-radius: 0.5rem;
   overflow: hidden;

--- a/frontend/src/components/EmployeeCards/EmployeeCards.tsx
+++ b/frontend/src/components/EmployeeCards/EmployeeCards.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import Card, { CardInfo } from '../Card/Card';
 import styles from './employeecards.module.css';
-import { clock, phone, wheel, user } from '../../icons/userInfo/index';
+import { phone, wheel, user } from '../../icons/userInfo/index'; // clock,
 import { Employee } from '../../types';
 import { useEmployees } from '../../context/EmployeesContext';
 import { AdminType } from '../../../../server/src/models/admin';
@@ -90,7 +90,7 @@ const EmployeeCard = ({
       .join('\n ');
   };
 
-  const parsedAvail = formatAvail(availability!);
+  //Avail = formatAvail(availability!);
   const isAdmin = isDriver !== undefined;
   const isBoth = isDriver && isDriver == true;
   const roles = (): string => {
@@ -106,7 +106,7 @@ const EmployeeCard = ({
     netId,
     type,
     phone: fmtPhone,
-    availability: parsedAvail,
+    // availability: parsedAvail,
     photoLink,
     startDate,
   };
@@ -130,15 +130,6 @@ const EmployeeCard = ({
         <CardInfo icon={phone} alt="phone">
           <p>{fmtPhone}</p>
         </CardInfo>
-
-        <CardInfo icon={clock} alt="clock">
-          {parsedAvail ? (
-            <p className={styles.timeText}>{parsedAvail}</p>
-          ) : (
-            <p>N/A</p>
-          )}
-        </CardInfo>
-
         <CardInfo
           icon={isAdmin || isBoth ? user : wheel}
           alt={isAdmin || isBoth ? 'admin' : 'wheel'}
@@ -150,6 +141,13 @@ const EmployeeCard = ({
   );
 };
 
+/* <CardInfo icon={clock} alt="clock">
+          {parsedAvail ? (
+            <p className={styles.timeText}>{parsedAvail}</p>
+          ) : (
+            <p>N/A</p>
+          )}
+        </CardInfo> */
 const searchableFields = (employee: DriverType | AdminType) => {
   const fields = [
     employee.firstName,


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes the styling on the employee card modal so that words aren't cut off and removes availabilities from the display. 

### Test Plan <!-- Required -->
Before: 
<img width="609" alt="Screenshot 2024-10-09 at 6 08 06 PM" src="https://github.com/user-attachments/assets/d211d0dd-299c-4c2b-a557-abcc0bea5d7f">

After:
<img width="649" alt="Screenshot 2024-10-09 at 6 06 48 PM" src="https://github.com/user-attachments/assets/f92b4a96-b1cc-408d-bf93-8de8638e3e37">

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
I commented out the availability information because I think it should be used somewhere else. Clicking on the employee card just redirects to the home page. Also uploading a picture for the profile picture doesn't work. 

### Breaking Changes <!-- Optional -->

<!-- Uncomment items that apply: -->

<!-- - Database schema change (anything that changes DynamoDB document structure)
<!-- - Other change that could cause problems (Detailed in notes)
