### PR TITLE
Fix CD pipeline

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -11,41 +11,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: context
-        uses: okteto/context@latest
-        with:
-          token: ${{ secrets.OKTETO_TOKEN }}
-
-      - name: 'Activate Namespace'
-        uses: okteto/namespace@latest
-        with:
-          namespace: pratyush1712
-
-      - name: 'Trigger the pipeline'
-        uses: okteto/pipeline@latest
-        with:
-          name: carriage-web
-          timeout: 30m
-          variables:
-            'AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }},
-            AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }},
-            JWT_SECRET=${{ secrets.JWT_SECRET }},
-            PUBLIC_VAPID_KEY=${{ secrets.PUBLIC_VAPID_KEY }},
-            PRIVATE_VAPID_KEY=${{ secrets.PRIVATE_VAPID_KEY }},
-            WEB_PUSH_CONTACT=${{ secrets.WEB_PUSH_CONTACT }},
-            IOS_DRIVER_ARN=${{ secrets.IOS_DRIVER_ARN }},
-            IOS_RIDER_ARN=${{ secrets.IOS_RIDER_ARN }},
-            ANDROID_ARN=${{ secrets.ANDROID_ARN }},
-            HOSTNAME=${{ secrets.HOSTNAME }},
-            USE_HOSTNAME=${{ secrets.USE_HOSTNAME }},
-            OAUTH_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }}
-            OAUTH_CLIENT_SECRET=${{ secrets.OAUTH_CLIENT_SECRET }}
-            REACT_APP_SERVER_URL=${{ secrets.REACT_APP_SERVER_URL }},
-            REACT_APP_CLIENT_ID=${{ secrets.REACT_APP_CLIENT_ID }},
-            REACT_APP_PUBLIC_VAPID_KEY=${{ secrets.REACT_APP_PUBLIC_VAPID_KEY }},
-            REACT_APP_ENCRYPTION_KEY=${{ secrets.REACT_APP_ENCRYPTION_KEY }},
-            DOMAIN=${{ secrets.DOMAIN }}'
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -2,7 +2,7 @@ name: Continuous Deployment to Staging
 
 on:
   push:
-    branches: [master, mk2672/fix-okteto]
+    branches: [master]
 
 jobs:
   deploy:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -2,7 +2,7 @@ name: Continuous Deployment to Staging
 
 on:
   push:
-    branches: [master]
+    branches: [master, mk2672/fix-okteto]
 
 jobs:
   deploy:


### PR DESCRIPTION
### Summary 
Removes Okteto from the CD pipeline, makes other robust CD deployment tests pass.

### Test Plan
N/A