### PR TITLE
Properly handle secrets in new Docker Build/Push CI

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -11,5 +11,7 @@ jobs:
       push: true
       tags: dticarriage/carriage-service:latest
       registry: docker.io
+    secrets:
+      inherit: true
       username: ${{ secrets.DOCKERHUB_USERNAME }}
       password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -19,5 +19,7 @@ jobs:
         org.opencontainers.image.title=PR-${{ github.event.pull_request.number }}
         org.opencontainers.image.description=${{ github.event.pull_request.title }}
       registry: ghcr.io
-      username: ${{ github.actor }}
-      password: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      inherit: true
+      username: ${{ secrets.DOCKERHUB_USERNAME }}
+      password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,6 +20,7 @@ on:
         description: 'Registry URL (optional)'
         required: false
         type: string
+    secrets:
       username:
         description: 'Registry password (optional)'
         required: false


### PR DESCRIPTION
### Summary

The previous PR #611 didn't properly handle secrets in the CI workflow definition and invocation. This PR is the first (and hopefully last) attempt to fix this.

- [x] convert Docker registry username and password to secrets
- [x] enable secrets.inherit: true for the workflow call