### PR TITLE
Remove incorrect `type` declarations in new GitHub Workflow secrets

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -24,11 +24,9 @@ on:
       username:
         description: 'Registry password (optional)'
         required: false
-        type: string
       password:
         description: 'Registry password (optional)'
         required: false
-        type: string
 
 jobs:
   build:


### PR DESCRIPTION
### Summary 

The previous version of the new GitHub CI changes, introduced in #612, include `type` parameters for secrets, which are incorrect. This PR removes these declarations and should properly fix the CI.