### PR TITLE
Refresh ride table on edit/submit ride

### DIFF
--- a/frontend/src/components/RideDetails/RideActions.tsx
+++ b/frontend/src/components/RideDetails/RideActions.tsx
@@ -175,7 +175,7 @@ const RideActions: React.FC<RideActionsProps> = ({
           refreshRides();
         }
 
-        if (isNewRide(ride) && onClose) {
+        if (onClose) {
           onClose(); // Close modal after creating new ride
         }
       } else {

--- a/frontend/src/pages/Rider/Schedule.tsx
+++ b/frontend/src/pages/Rider/Schedule.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState, useCallback } from 'react';
 import { Button } from '@mui/material';
 import { Ride } from '../../types';
 import AuthContext from '../../context/auth';
@@ -115,24 +115,24 @@ const Schedule: React.FC = () => {
     });
   };
 
+  const fetchRiderRides = useCallback(async () => {
+    if (id) {
+      setLoadingRides(true);
+      try {
+        const rides = await refreshRidesByUser(id, 'rider');
+        setAllRiderRides(rides);
+      } catch (error) {
+        console.error('Failed to fetch rider rides:', error);
+      } finally {
+        setLoadingRides(false);
+      }
+    }
+  }, [id, refreshRidesByUser]);
+
   // Fetch all rider rides on component mount
   useEffect(() => {
-    const fetchRiderRides = async () => {
-      if (id) {
-        setLoadingRides(true);
-        try {
-          const rides = await refreshRidesByUser(id, 'rider');
-          setAllRiderRides(rides);
-        } catch (error) {
-          console.error('Failed to fetch rider rides:', error);
-        } finally {
-          setLoadingRides(false);
-        }
-      }
-    };
-
     fetchRiderRides();
-  }, [id, refreshRidesByUser]);
+  }, [fetchRiderRides]);
 
   useEffect(() => {
     document.title = 'Schedule - Carriage';
@@ -187,6 +187,7 @@ const Schedule: React.FC = () => {
       // Refresh rides after successful creation
       await refreshRides();
       console.log('Ride created successfully');
+      fetchRiderRides();
     } catch (error) {
       console.error('Failed to create ride:', error);
       alert('Failed to create ride. Please try again.');
@@ -411,7 +412,10 @@ const Schedule: React.FC = () => {
           <RideDetailsComponent
             ride={editingRide}
             open={editingRide !== null}
-            onClose={() => setEditingRide(null)}
+            onClose={() => {
+              setEditingRide(null);
+              fetchRiderRides();
+            }}
           ></RideDetailsComponent>
         )}
       </main>


### PR DESCRIPTION
### Summary

This pull request is the first step towards solving bugs raised by CULift/SDS: when a ride is submitted or edited, the ride table doesn't refresh, which is confusing. Now, the ride table is refreshed after rides are added and edited (also, after a completed edit we go to the rides table now instead of the view of the ride detail view).

### Test Plan
These are minor changes which I tested through use of the website. 

### Notes <!-- Optional -->
This makes the website pretty slow/clunky without #636.