### PR TITLE
Remove report button

### DIFF
--- a/frontend/src/components/RideDetails/RideActions.tsx
+++ b/frontend/src/components/RideDetails/RideActions.tsx
@@ -25,7 +25,6 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import PhoneIcon from '@mui/icons-material/Phone';
 import EmailIcon from '@mui/icons-material/Email';
 import UpdateIcon from '@mui/icons-material/Update';
-import ReportIcon from '@mui/icons-material/Report';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import CloseIcon from '@mui/icons-material/Close';
 import { RideType, Status, SchedulingState } from '../../types';
@@ -199,10 +198,6 @@ const RideActions: React.FC<RideActionsProps> = ({
     stopEditing();
   };
 
-  const handleReport = () => {
-    // In a real app, open report issue dialog
-  };
-
   const renderRiderActions = () => {
     if (canEdit) {
       return (
@@ -262,15 +257,6 @@ const RideActions: React.FC<RideActionsProps> = ({
               >
                 {isMobile ? <CancelIcon /> : 'Cancel Ride'}
               </Button>
-              <Button
-                variant="outlined"
-                startIcon={!isMobile ? <ReportIcon /> : undefined}
-                onClick={handleReport}
-                fullWidth={isMobile}
-                aria-label="Report issue"
-              >
-                {isMobile ? <ReportIcon /> : 'Report'}
-              </Button>
             </>
           )}
         </Stack>
@@ -286,15 +272,6 @@ const RideActions: React.FC<RideActionsProps> = ({
             aria-label="Contact Admin"
           >
             {isMobile ? <AdminPanelSettingsIcon /> : 'Contact Admin'}
-          </Button>
-          <Button
-            variant="outlined"
-            startIcon={!isMobile ? <ReportIcon /> : undefined}
-            onClick={handleReport}
-            fullWidth={isMobile}
-            aria-label="Report issue"
-          >
-            {isMobile ? <ReportIcon /> : 'Report'}
           </Button>
         </Stack>
       );
@@ -317,15 +294,6 @@ const RideActions: React.FC<RideActionsProps> = ({
         }
       >
         {isMobile ? <UpdateIcon /> : 'Update Status'}
-      </Button>
-      <Button
-        variant="outlined"
-        startIcon={!isMobile ? <ReportIcon /> : undefined}
-        onClick={handleReport}
-        fullWidth={isMobile}
-        aria-label="Report issue"
-      >
-        {isMobile ? <ReportIcon /> : 'Report'}
       </Button>
     </Stack>
   );


### PR DESCRIPTION
### Summary <!-- Required -->
This PR removes the report button on the student side. This button is nonfunctional in the current version of the app and SSIT suggested that it be removed.

### Test Plan <!-- Required -->
None / not necessary.

### Notes <!-- Optional -->
The idea behind this button, to my knowledge, was reporting issues with drivers or a ride; however, given the small size of CULift in terms of user base/drivers, we think it makes more sense for users to contact admin directly (which there's another button for). Overall, I made this PR because I think the report button isn't necessary, but if anyone disagrees we should discuss in the comments.