### PR TITLE
Fix ride table headers

### DIFF
--- a/frontend/src/components/UserTables/CancelledTable.tsx
+++ b/frontend/src/components/UserTables/CancelledTable.tsx
@@ -34,7 +34,7 @@ const CancelledTable = () => {
         return driverRides.length ? (
           <React.Fragment key={id}>
             <h1 className={styles.formHeader}>{name}</h1>
-            <RidesTable rides={driverRides} hasButtons={true} />
+            <RidesTable rides={driverRides} />
           </React.Fragment>
         ) : null;
       })}

--- a/frontend/src/components/UserTables/RidesTable.tsx
+++ b/frontend/src/components/UserTables/RidesTable.tsx
@@ -8,15 +8,13 @@ import styles from './table.module.css';
 import { useEmployees } from '../../context/EmployeesContext';
 import { useRides } from '../../context/RidesContext';
 import DeleteOrEditTypeModal from '../Modal/DeleteOrEditTypeModal';
-import { trashbig } from '../../icons/other/index';
 import buttonStyles from '../../styles/button.module.css';
 
 type RidesTableProps = {
   rides: Ride[];
-  hasButtons: boolean;
 };
 
-const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
+const RidesTable = ({ rides }: RidesTableProps) => {
   const { drivers } = useEmployees();
   const { getRideById } = useRides();
   const [openAssignModal, setOpenAssignModal] = useState(-1);
@@ -35,17 +33,6 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
     setSelectedRide(null);
   };
 
-  const unscheduledColSizes = [0.5, 0.5, 0.8, 1, 1, 0.8, 1];
-  const unscheduledHeaders = [
-    '',
-    'Time',
-    'Pickup Location',
-    'Dropoff Location',
-    'Needs',
-    'Passenger',
-    '',
-  ];
-
   const scheduledColSizes = [0.5, 0.5, 1, 1, 1, 1, 1];
   const scheduledHeaders = [
     'Pickup Time',
@@ -62,8 +49,8 @@ const RidesTable = ({ rides, hasButtons }: RidesTableProps) => {
       <Table>
         <Row
           header
-          colSizes={hasButtons ? unscheduledColSizes : scheduledColSizes}
-          data={hasButtons ? unscheduledHeaders : scheduledHeaders}
+          colSizes={scheduledColSizes}
+          data={scheduledHeaders}
         />
         {rides.filter((ride) => ride !== undefined).map((ride, index) => {
           const startTime = new Date(ride.startTime).toLocaleTimeString([], {

--- a/frontend/src/components/UserTables/ScheduledTable.tsx
+++ b/frontend/src/components/UserTables/ScheduledTable.tsx
@@ -34,14 +34,14 @@ const ScheduledTable = () => {
         return driverRides.length ? (
           <React.Fragment key={id}>
             <h1 className={styles.formHeader}>{name}</h1>
-            <RidesTable rides={driverRides} hasButtons={true} />
+            <RidesTable rides={driverRides} />
           </React.Fragment>
         ) : null;
       })}
       {rides.filter((ride) => ride?.driver === undefined).map((ride) => (
         <React.Fragment key={ride.id}>
           <h1 className={styles.formHeader}>Unassigned</h1>
-          <RidesTable rides={[ride]} hasButtons={true} />
+          <RidesTable rides={[ride]} />
         </React.Fragment>
       ))}
     </>

--- a/frontend/src/components/UserTables/UnscheduledTable.tsx
+++ b/frontend/src/components/UserTables/UnscheduledTable.tsx
@@ -20,7 +20,7 @@ const Table = () => {
     setRides(unscheduledRides.sort(compRides));
   }, [unscheduledRides]);
 
-  return rides.length ? <RidesTable rides={rides} hasButtons={true} /> : (
+  return rides.length ? <RidesTable rides={rides} /> : (
     <div className={styles.noRides}>No unscheduled rides</div>
   );
 };


### PR DESCRIPTION
### Summary 
Ride table headers were out of order. This fixes that.

### Test Plan <!-- Required -->
Not necessary.

### Notes <!-- Optional -->
Removed the `hasButtons` boolean from the RidesTable props, which was manually being set to True in every mention of the RidesTable and appears outdated.